### PR TITLE
fix(docker): correct secret reference

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Docker Build
-        run: docker build . -t ${{ env.TAG_UNIQUE }} -t ${{ env.TAG_LATEST }}
+        run: docker build . -t "${TAG_UNIQUE}" -t "${TAG_LATEST}"
 
       - name: Docker Login
         uses: azure/docker-login@v1
@@ -54,5 +54,5 @@ jobs:
 
       - name: Docker Push
         run: |
-          docker push ${{ env.TAG_UNIQUE }}
-          docker push ${{ env.TAG_LATEST }}
+          docker push "${TAG_UNIQUE}"
+          docker push "${TAG_LATEST}"


### PR DESCRIPTION
Fix incorrect reference to `acr_login_server` as input instead of secret.

Also wrapped references to env vars in bash scripts with double quotes, to prevent injection exploits.