### PR TITLE
feat: add super-linter

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,6 +1,6 @@
-# Run the GitHub Super-Linter to validate the codebase.
+# Run GitHub Super-Linter to validate the codebase.
 
-name: Lint
+name: Lint Codebase
 
 on:
   pull_request:
@@ -10,7 +10,7 @@ on:
   workflow_call:
 
 jobs:
-  lint:
+  super-linter:
     name: Super-Linter
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Add a reusable workflow for the GitHub Super-Linter.

This should make it easier to setup the Super-Linter with a consistent config across all repos that we work on.

Also added a trigger on pull request, to lint this repo as well.