### PR TITLE
fix: remove trailing forward slash

### DIFF
--- a/scripts/oidc/oidc.json
+++ b/scripts/oidc/oidc.json
@@ -1,7 +1,7 @@
 {
   "federatedCredential": {
     "name": "github-actions",
-    "issuer": "https://token.actions.githubusercontent.com/",
+    "issuer": "https://token.actions.githubusercontent.com",
     "subject": "repo:${REPO}:environment:${ENVIRONMENT}",
     "description": "OIDC auth from GitHub Actions to Azure",
     "audiences": [


### PR DESCRIPTION
Remove trailing forward slash from `issuer` to prevent error `AADSTS70021` when using `azure/login@v1` action.