### PR TITLE
chore: create perm access to terraform backend only for sps

### DIFF
--- a/scripts/terraform-backend/README.md
+++ b/scripts/terraform-backend/README.md
@@ -7,7 +7,7 @@ It accepts the following arguments:
 1. The name of the storage account to create.
 1. The name of the Azure resource group to create the storage account in.
 1. The Azure region to create the storage account in.
-1. (Optional) The ID of the Azure AD object (user, group or service principal) that should be authorized to access the storage account.
+1. (Optional) The object ID of the Azure AD service principal that should be authorized to access the storage account.
 
 ## Prerequisites
 
@@ -40,11 +40,13 @@ It accepts the following arguments:
     ./terraform-backend.sh tfstate$RANDOM tfstate northeurope 00000000-0000-0000-0000-000000000000
     ```
 
-    If the Terraform backend is to be accessed by a user or group, it is recommended to manage access using [Azure AD PIM](https://learn.microsoft.com/en-us/azure/active-directory/privileged-identity-management/pim-configure) instead. In this case, run the script without passing a value to the object ID argument:
+    If the backend should not be accessed by a service principal, simply omit the object ID:
 
     ```bash
     ./terraform-backend.sh tfstate$RANDOM tfstate northeurope
     ```
+
+    If the backend should be accessed by a user or group, it is recommended to manage access using [Azure AD PIM](https://learn.microsoft.com/en-us/azure/active-directory/privileged-identity-management/pim-configure) instead.
 
 ## References
 

--- a/scripts/terraform-backend/terraform-backend.sh
+++ b/scripts/terraform-backend/terraform-backend.sh
@@ -6,7 +6,7 @@ readonly STORAGE_ACCOUNT_NAME="$1"
 readonly RESOURCE_GROUP_NAME="$2"
 readonly LOCATION="$3"
 readonly CONTAINER_NAME='tfstate'
-readonly OBJECT_ID="${4:-}"
+readonly SP_OBJECT_ID="${4:-}"
 
 az group create \
   --name "${RESOURCE_GROUP_NAME}" \
@@ -50,9 +50,10 @@ az storage container create \
   --auth-mode login \
   --output none
 
-if [[ -n "${OBJECT_ID}" ]]; then
+if [[ -n "${SP_OBJECT_ID}" ]]; then
   az role assignment create \
-    --assignee "${OBJECT_ID}" \
+    --assignee-object-id "${SP_OBJECT_ID}" \
+    --assignee-principal-type ServicePrincipal \
     --role 'Storage Blob Data Owner' \
     --scope "${storage_account_id}" \
     --output none


### PR DESCRIPTION
Create permanent access to Terraform backend only for service principals. For users and groups, use Azure AD PIM instead.