### PR TITLE
feat(semantic-release): add inputs to pin tools to a specific version

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -34,13 +34,13 @@ on:
           conventional-changelog-conventionalcommits
 
       node_version:
-        description:
+        description: Specify specific version of Node.js, with default set to latest version.
         type: string
         required: false
         default: lts/*
 
       semantic_version:
-        description:
+        description: Specify specific version of semantic-release, with default set to latest version.
         type: string
         required: false
         default: latest
@@ -77,4 +77,4 @@ jobs:
         run: |
           readarray -t branches_array <<< "$BRANCHES"
           readarray -t plugins_array <<< "$PLUGINS"
-          npx "semantic-release@$SEMANTIC_VERISON" --branches "${branches_array[@]}" --plugins "${plugins_array[@]}" --preset "$PRESET"
+          npx "semantic-release@$SEMANTIC_VERSION" --branches "${branches_array[@]}" --plugins "${plugins_array[@]}" --preset "$PRESET"


### PR DESCRIPTION
Add to new inputs, `node_version` and `semantic_version`, to enable tools to be pinned to a specific version. 
Default values set to latest version. 