### PR TITLE
fix(build-dotnet): store source and output in separate directories

### DIFF
--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -59,6 +59,7 @@ jobs:
       RUNTIME: ${{ inputs.runtime }}
       SELF_CONTAINED: ${{ inputs.self_contained }}
       OUTPUT: dotnet-app
+      ZIP_FILE: ${{ inputs.artifact_name }}.zip
 
     steps:
       - name: Checkout
@@ -91,16 +92,11 @@ jobs:
 
       # Zip Dotnet publish output in order to drastically improve artifact upload performance.
       - name: Zip
-        id: zip
-        env:
-          ZIP_FILE: ${{ runner.temp }}/${{ inputs.artifact_name }}.zip
-        run: |
-          zip -r "$ZIP_FILE" "$OUTPUT"
-          echo "zip_file=$ZIP_FILE" >> "$GITHUB_OUTPUT"
+        run: zip -r "$ZIP_FILE" "$OUTPUT"
 
       # Upload an artifact containing the application.
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
           name: ${{ inputs.artifact_name }}
-          path: ${{ steps.zip.outputs.zip_file }}
+          path: ${{ env.ZIP_FILE }}


### PR DESCRIPTION
Could prevent an issue where the repo containing the source code has a directory at root called `dotnet-app`. The build output would then be stored in that directory, together with whatever files were already there.

Update workflow to separate source code and build output into separate directories in order to prevent this.