### PR TITLE
chore: output extra config argument in oidc.sh

### DIFF
--- a/scripts/terraform-backend/terraform-backend.sh
+++ b/scripts/terraform-backend/terraform-backend.sh
@@ -68,4 +68,5 @@ az resource lock create \
 
 echo "resource_group_name = \"${RESOURCE_GROUP_NAME}\"
 storage_account_name = \"${STORAGE_ACCOUNT_NAME}\"
-container_name = \"${CONTAINER_NAME}\""
+container_name = \"${CONTAINER_NAME}\"
+use_azuread_auth = true"


### PR DESCRIPTION
Explicitly configure backend to use Azure AD authentication.

Even though it's already configured in the `terraform.yml` workflow, configuring it in the backend configuration itself makes sure Azure AD authentication is used when running Terraform locally as well.
