### PR TITLE
revert: use azuread for terraform azure backend auth

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -62,7 +62,6 @@ jobs:
       # Configure OIDC authentication to Azure using environment variables.
       # Required by the AzureRM backend and provider.
       ARM_USE_OIDC: true
-      ARM_USE_AZUREAD: true
       ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}


### PR DESCRIPTION
The idea of 08e20d7 was to integrate Azure AD authentication for the Terraform Azure backend directly into the GitHub workflow. This would allow us to omit `use_azuread_auth` from all of our Terraform configurations, since it would be set at the workflow level instead.

This proved troublesome when I tried to run a Terraform configuration locally, because the Azure backend was setup to only allow Azure AD authentication, however my the backend configuration did not have `use_azuread_auth` explicitly set.

Thus, it has proven to be a better idea to set `use_azuread_auth` in the relevant Terraform configuration instead.

Refs: 08e20d7
