### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @equinor/ops-coredev


### PR DESCRIPTION
Add CODEOWNERS.

Also updated branch protection rule for branch `main` to require PR approval from at least one code owner for all future PRs.