### PR TITLE
feat: zip/unzip artifacts to improve upload/download performance

### DIFF
--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -62,9 +62,18 @@ jobs:
       - name: Dotnet publish
         run: dotnet publish --configuration "$CONFIGURATION" --runtime "$RUNTIME" --self-contained "$SELF_CONTAINED" --output "$OUTPUT" --no-build
 
+      # Zip Dotnet publish output in order to drastically improve artifact upload performance.
+      - name: Zip
+        id: zip
+        env:
+          ZIP_FILE: ${{ runner.temp }}/${{ inputs.artifact_name }}.zip
+        run: |
+          zip -r "$ZIP_FILE" "$OUTPUT"
+          echo "zip_file=$ZIP_FILE" >> "$GITHUB_OUTPUT"
+
       # Upload an artifact containing the application.
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
           name: ${{ inputs.artifact_name }}
-          path: ${{ env.OUTPUT }}
+          path: ${{ steps.zip.outputs.zip_file }}

--- a/.github/workflows/deploy-azure-webapp.yml
+++ b/.github/workflows/deploy-azure-webapp.yml
@@ -63,6 +63,14 @@ jobs:
         with:
           name: ${{ inputs.artifact_name }}
 
+      - name: Unzip
+        if: inputs.artifact_name != ''
+        env:
+          ZIP_FILE: ${{ inputs.artifact_name }}.zip
+        run: |
+          unzip "$ZIP_FILE"
+          rm "$ZIP_FILE"
+
       - name: Login to Azure
         uses: azure/login@v1
         with:


### PR DESCRIPTION
Artifact upload/download performs HTTP calls per file being uploaded. By zipping files before uploading, we can drastically reduce this upload time. [Ref.](https://github.com/actions/upload-artifact#too-many-uploads-resulting-in-429-responses)

Update build workflows to zip files before uploading artifact.
Update deploy worfklows to unzip downloaded artifacts.