### PR TITLE
feat(azure-function): configure app settings

### DIFF
--- a/.github/workflows/deploy-azure-function.yml
+++ b/.github/workflows/deploy-azure-function.yml
@@ -16,6 +16,12 @@ on:
         type: string
         required: true
 
+      app_settings:
+        description: App settings to configure for the Azure Function App. Space-separated KEY=VALUE format or inline JSON.
+        type: string
+        default: "{}"
+        required: false
+
     secrets:
       AZURE_CLIENT_ID:
         description: The client ID of the Azure AD service principal to use for authenticating to Azure.
@@ -41,7 +47,6 @@ jobs:
 
     steps:
       - name: Download artifact
-        id: download
         uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.artifact_name }}
@@ -65,4 +70,12 @@ jobs:
         uses: azure/functions-action@v1
         with:
           app-name: ${{ inputs.app_name }}
-          package: ${{ steps.download.outputs.download-path }}
+
+      - name: Configure app settings
+        env:
+          APP_NAME: ${{ inputs.app_name }}
+          APP_SETTINGS: ${{ inputs.app_settings }}
+        run: |
+          RESOURCE_GROUP=$(az functionapp list --query "[?name=='$APP_NAME'].resourceGroup" -o tsv)
+          echo "Resource group: $RESOURCE_GROUP"
+          az functionapp config appsettings set -n "$APP_NAME" -g "$RESOURCE_GROUP" --settings "$APP_SETTINGS" -o json


### PR DESCRIPTION
Configure app settings for the deployed Function App.

Using Azure CLI instead of the official `Azure/appservice-settings` action for two reasons:

- The official action has not been updated in 2 years. As a result, using it gives a warning that it is using GitHub Actions related functions that are deprecated.
- The official action only supports one format for app settings:

    ```json
    [
      {
        "name": "CLIENT_ID",
        "value": "67837c7a-73ce-456e-b6bf-fdd20f0854c5",
        "slotSetting": "false"
      },
      {
        "name": "CLIENT_SECRET",
        "value": "@Microsoft.KeyVault(VaultName=example-kv;SecretName=client-secret)",
        "slotSetting": "false"
      }
    ]
    ```

    That's five lines of inline JSON per setting!

    Azure CLI supports the above format, in addition to a simpler KEY=VALUE inline JSON format:

    ```json
    {
      "CLIENT_ID": "67837c7a-73ce-456e-b6bf-fdd20f0854c5",
      "CLIENT_SECRET": "@Microsoft.KeyVault(VaultName=example-kv;SecretName=client-secret)"
    }
    ```

    It also supports space-separated KEY=VALUE format. By using the `>` key in YAML, we can create a multiline string with one app setting per line:

    ```yaml
    app_settings: >
      CLIENT_ID=67837c7a-73ce-456e-b6bf-fdd20f0854c5
      CLIENT_SECRET=@Microsoft.KeyVault(VaultName=example-kv;SecretName=client-secret)
    ```

    It also supports using @{file} to load from a file, however we don't checkout our source code in this workflow so that is not relevant to us, as no files from our repo will be available.