### PR TITLE
feat(dotnet): set CI environment variable

### DIFF
--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -106,11 +106,11 @@ jobs:
       # Zip Dotnet publish output in order to drastically improve artifact upload performance.
       - name: Zip
         id: zip
+        working-directory: ${{ steps.publish.outputs.publish_path }}
         env:
           ZIP_FILE: ${{ runner.temp }}/${{ inputs.artifact_name }}.zip
-          PUBLISH_PATH: ${{ steps.publish.outputs.publish_path }}
         run: |
-          zip -r "$ZIP_FILE" "$PUBLISH_PATH"
+          zip -r "$ZIP_FILE" .
           echo "zip_file=$ZIP_FILE" >> "$GITHUB_OUTPUT"
 
       # Upload an artifact containing the application.


### PR DESCRIPTION
Environment variable `CI` is set to `true` by default in GitHub Actions. This has caused some issues for us where NPM warnings are treated as errors. This is not always the desired behavior, thus we needed a way to change it.