### PR TITLE
refactor(dotnet): specify self-contained build

### DIFF
--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -96,6 +96,7 @@ jobs:
           while read -r p; do
             dotnet test "$p" --configuration "$CONFIGURATION" --runtime "$RUNTIME" --collect "$COLLECT"
           done <<< "$PROJECT"
+        # The dotnet test command does not support the '--self-contained' option as of Mar 8, 2023 (https://github.com/dotnet/sdk/issues/31066).
 
       # Publish the application and its dependencies to a folder for deployment.
       - name: Dotnet publish


### PR DESCRIPTION
Prevents the following warning:

```text
warning NETSDK1179: One of '--self-contained' or '--no-self-contained' options are required when '--runtime' is used.
```