### PR TITLE
fix(dotnet): trim trailing newlines for test projects

### DIFF
--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -93,9 +93,11 @@ jobs:
           PROJECT: ${{ inputs.test_project }}
           COLLECT: ${{ inputs.test_collect }}
         run: |
+          echo "$PROJECT" |
+          tr -s "\n" |
           while read -r p; do
             dotnet test "$p" --configuration "$CONFIGURATION" --runtime "$RUNTIME" --collect "$COLLECT"
-          done <<< $(echo "$PROJECT" | sed -z "s/\n$//")
+          done
         # The dotnet test command does not support the '--self-contained' option as of Mar 8, 2023 (https://github.com/dotnet/sdk/issues/31066).
 
       # Publish the application and its dependencies to a folder for deployment.


### PR DESCRIPTION
Trim newlines to prevent interpreting empty lines as test projects.

For example, the following input:

```text

tests/Example.UnitTests/Example.UnitTests.csproj


tests/Example.IntegrationTests/Example.IntegrationTests.csproj





```

will be trimmed to:

```text
tests/Example.UnitTests/Example.UnitTests.csproj
tests/Example.IntegrationTests/Example.IntegrationTests.csproj
```