### PR TITLE
fix: correct supported app settings formats

### DIFF
--- a/.github/workflows/deploy-azure-function.yml
+++ b/.github/workflows/deploy-azure-function.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Configure app settings
         if: inputs.app_settings != ''
-        uses: azure/appservice-settings
+        uses: azure/appservice-settings@v1
         with:
           app-name: ${{ inputs.app_name }}
           app-settings-json: ${{ inputs.app_settings }}

--- a/.github/workflows/deploy-azure-webapp.yml
+++ b/.github/workflows/deploy-azure-webapp.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Configure app settings
         if: inputs.app_settings != ''
-        uses: azure/appservice-settings
+        uses: azure/appservice-settings@v1
         with:
           app-name: ${{ inputs.app_name }}
           app-settings-json: ${{ inputs.app_settings }}


### PR DESCRIPTION
Turns out the space-separeted key=value format does not work when specifying multiple app settings to be configured.

This PR simply corrects the descriptions of the relevant inputs, and reverts to using the offical appservice settings action, as there is no reason to use Az CLI anymore since it's not giving us any advantages.

Basically reverts the changes implemented in v6.5.0.