### PR TITLE
fix: don't mask app settings

### DIFF
--- a/.github/workflows/deploy-azure-function.yml
+++ b/.github/workflows/deploy-azure-function.yml
@@ -76,3 +76,4 @@ jobs:
         with:
           app-name: ${{ inputs.app_name }}
           app-settings-json: ${{ inputs.app_settings }}
+          mask-inputs: false

--- a/.github/workflows/deploy-azure-webapp.yml
+++ b/.github/workflows/deploy-azure-webapp.yml
@@ -88,3 +88,4 @@ jobs:
         with:
           app-name: ${{ inputs.app_name }}
           app-settings-json: ${{ inputs.app_settings }}
+          mask-inputs: false


### PR DESCRIPTION
App settings should never contain hard coded secrets, so no reason to mask them as this would only complicate troubleshooting.