### PR TITLE
revert(dotnet): trim trailing newlines for test projects

### DIFF
--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -93,7 +93,6 @@ jobs:
           COLLECT: ${{ inputs.test_collect }}
         run: |
           echo "$PROJECT" |
-          tr -s "\n" |
           while read -r p; do
             dotnet test "$p" --configuration "$CONFIGURATION" --runtime "$RUNTIME" --collect "$COLLECT"
           done


### PR DESCRIPTION
Logic to trim newlines doesn't work as expected in all scenarios (e.g. when input string contains leading newline).

Refs: 1a72941