### PR TITLE
chore: set explicit sign-in-audience for OIDC app

### DIFF
--- a/scripts/oidc/oidc.sh
+++ b/scripts/oidc/oidc.sh
@@ -45,7 +45,7 @@ echo "Checking if application already exists..."
 app_id=$(az ad app list --filter "displayName eq '$APP_NAME'" --query [].appId --output tsv)
 if [[ -z "$app_id" ]]; then
   echo "Creating application..."
-  app_id=$(az ad app create --display-name "$APP_NAME" --query appId --output tsv)
+  app_id=$(az ad app create --display-name "$APP_NAME" --sign-in-audience AzureADMyOrg --query appId --output tsv)
 else
   echo "Using existing application."
 fi

--- a/scripts/oidc/pwsh/oidc.psm1
+++ b/scripts/oidc/pwsh/oidc.psm1
@@ -97,7 +97,7 @@ function New-GitHubConnectionOIDC {
         try {
             if ($null -eq $spClientId) {
                 Write-Output 'Creating application...'
-                $spClientId = az ad app create --display-name $AppRegistrationName --query appId --output tsv
+                $spClientId = az ad app create --display-name $AppRegistrationName --sign-in-audience AzureADMyOrg --query appId --output tsv
             }
             else {
                 Write-Output "Using existing application."
@@ -218,8 +218,8 @@ function New-GitHubConnectionOIDC {
             Write-Output "Starting RBAC Assignment for Resource Groups"
             Write-Output "Reading config..."
 
-            $config         = Get-Content $ConfigFile | ConvertFrom-Json -AsHashtable
-            $rbacRole       = $config.roleAssignments.$RbacScope.$Environment.rbacRole
+            $config = Get-Content $ConfigFile | ConvertFrom-Json -AsHashtable
+            $rbacRole = $config.roleAssignments.$RbacScope.$Environment.rbacRole
             $resourceGroups = $config.roleAssignments.$RbacScope.$Environment.resourceGroups
 
             Write-Output "Checking and creating RBAC Role Assignments..."
@@ -239,7 +239,7 @@ function New-GitHubConnectionOIDC {
             Write-Output "Starting RBAC Assignment for Subscription"
             Write-Output "Reading config..."
 
-            $config   = Get-Content $ConfigFile | ConvertFrom-Json -AsHashtable
+            $config = Get-Content $ConfigFile | ConvertFrom-Json -AsHashtable
             $rbacRole = $config.roleAssignments.$RbacScope.rbacRole
 
             try {


### PR DESCRIPTION
Prevent issue where certain versions of the Azure API seem to set this to other values.