### PR TITLE
docs: MkDocs workflow triggers on given paths

### DIFF
--- a/docs/usage-examples.md
+++ b/docs/usage-examples.md
@@ -163,6 +163,9 @@ name: deploy
 on:
   push:
     branches: [main]
+    paths:
+      - docs/**
+      - mkdocs.yml
 
 jobs:
   deploy:


### PR DESCRIPTION
When hosting MkDocs locally, the following information will be written to the console:

```console
$ mkdocs serve
INFO     -  Building documentation...
INFO     -  Cleaning site directory
INFO     -  Documentation built in 0.57 seconds
INFO     -  [09:37:52] Watching paths for changes: 'docs', 'mkdocs.yml'
INFO     -  [09:37:52] Serving on http://127.0.0.1:8000/ops-actions/
INFO     -  [09:37:54] Browser connected: http://127.0.0.1:8000/ops-actions/
```

As seen in the above output, MkDocs watches for changes in the `docs` directory and the `mkdocs.yml` file.

Update the MkDocs workflow usage example to mimic this behaviour.