### PR TITLE
chore: delete old Terraform state files

### DIFF
--- a/scripts/terraform-backend/README.md
+++ b/scripts/terraform-backend/README.md
@@ -12,6 +12,7 @@ It accepts the following arguments:
 ## Prerequisites
 
 - [Install Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli).
+- [Install jq](https://stedolan.github.io/jq/download/) - to create lifecycle management policy.
 - Azure role `Owner` at the subscription scope.
 
 ## Usage

--- a/scripts/terraform-backend/terraform-backend.sh
+++ b/scripts/terraform-backend/terraform-backend.sh
@@ -50,6 +50,36 @@ az storage container create \
   --auth-mode login \
   --output none
 
+management_policy=$(jq --null-input '{
+  rules: [
+    {
+      name: "delete-old-versions",
+      enabled: true,
+      type: "Lifecycle",
+      definition: {
+        actions: {
+          version: {
+            delete: {
+              daysAfterCreationGreaterThan: 30,
+            }
+          }
+        },
+        filters: {
+          blobTypes: [
+            "blockBlob"
+          ]
+        }
+      }
+    }
+  ]
+}')
+
+az storage account management-policy create \
+  --account-name "${STORAGE_ACCOUNT_NAME}" \
+  --resource-group "${RESOURCE_GROUP_NAME}" \
+  --policy "${management_policy}" \
+  --output none
+
 if [[ -n "${SP_OBJECT_ID}" ]]; then
   az role assignment create \
     --assignee-object-id "${SP_OBJECT_ID}" \


### PR DESCRIPTION
Update `terraform-backend.sh` to create lifecycle management policy for storage account to automatically delete old terraform state files.