### PR TITLE
fix(terraform): pass pass through envvar before comment

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -97,6 +97,8 @@ jobs:
       - name: Create PR comment
         uses: actions/github-script@v6
         if: github.event_name == 'pull_request' && (success() || failure())
+        env:
+          PLAN: ${{ steps.plan.outputs.stdout }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -120,7 +122,7 @@ jobs:
             <details><summary>Show Plan</summary>
 
             \`\`\`terraform
-            ${{ steps.plan.outputs.stdout }}
+            ${process.env.PLAN}
             \`\`\`
 
             </details>


### PR DESCRIPTION
Some plans were causing errors when trying to create PR comments.

Pass the plan through an envvar to force it to be a string. Has been tested to work on the jobs that were failing.