### PR TITLE
feat(docker): build and push to Docker registry

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,80 @@
+# Login to a Docker registry, then build and push Docker image.
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: The name of the GitHub environment that this job references.
+        type: string
+        required: false
+
+      working_directory:
+        description: The path of the working directory containing the Dockerfile to build an image from.
+        type: string
+        default: "."
+        required: false
+
+      registry:
+        description: The URL of the Docker registry to push the image to.
+        type: string
+        required: true
+
+      username:
+        description: The username used to login to the Docker registry.
+        type: string
+        required: true
+
+      repository:
+        description: The repository in the Docker registry to push the image to.
+        type: string
+        required: true
+
+      tag:
+        description: A tag for the image.
+        type: string
+        required: false
+        default: ${{ github.run_number }}
+
+    secrets:
+      password:
+        description: The password used to login to the Docker registry.
+        required: true
+
+    outputs:
+      image:
+        description: The Docker image that was built.
+        value: ${{ jobs.docker.outputs.image }}
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+
+    env:
+      IMAGE: ${{ inputs.registry }}/${{ inputs.repository }}:${{ inputs.tag }}
+      IMAGE_LATEST: ${{ inputs.registry }}/${{ inputs.repository }}:latest
+
+    outputs:
+      image: ${{ env.IMAGE }}
+      image_latest: ${{ env.IMAGE_LATEST }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ inputs.registry }}
+          username: ${{ inputs.username }}
+          password: ${{ secrets.password }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: ${{ inputs.working_directory }}
+          tags: ${{ env.IMAGE }},${{ env.IMAGE_LATEST }}
+          push: true


### PR DESCRIPTION
Build and push Docker image to any generic Docker registry.

We already have a workflow `docker-acr.yml`, however that is specifically for pushing to an Azure Container Registry.
That workflow uses OIDC authentication, which is more secure than the generic username/password, so this new workflow should be considered a "fallback" to that ACR workflow.