### PR TITLE
fix(terraform): don't run Apply without approval

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -4,7 +4,7 @@ on:
       environment:
         description: The environment that the job references.
         type: string
-        required: false
+        required: true
 
       working_directory:
         description: The working directory to run the Terraform commands in.


### PR DESCRIPTION
Set environment input as required to prevent running Terraform Apply without
manual approval.