### PR TITLE
feat(terraform): skip Apply if no changes present

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -80,7 +80,7 @@ jobs:
         working-directory: ${{ inputs.working_directory }}
 
     outputs:
-      plan-exitcode: ${{ steps.plan.outputs.exitcode }}
+      upload-outcome: ${{ steps.upload.outcome }}
 
     steps:
       - name: Checkout
@@ -137,11 +137,17 @@ jobs:
           *Pusher: @$GITHUB_ACTOR, Action: \`$GITHUB_EVENT_NAME\`, Working Directory: \`$WORKING_DIRECTORY\`, Workflow: \`$GITHUB_WORKFLOW\`*" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Archive Terraform config
+        id: archive
+        # Only run if Terraform Plan succeeded with non-empty diff (changes present).
+        # Ref: https://developer.hashicorp.com/terraform/cli/commands/plan#detailed-exitcode
+        if: steps.plan.outputs.exitcode == 2
         run: |
           tar -cf terraform.tar .
           7z a -p"$ENCRYPTION_PASSWORD" terraform.tar.7z terraform.tar
 
       - name: Upload artifact
+        id: upload
+        if: steps.archive.outcome == 'success'
         uses: actions/upload-artifact@v3
         with:
           name: ${{ inputs.artifact_name }}
@@ -151,11 +157,7 @@ jobs:
   terraform:
     name: Terraform
     needs: terraform-plan
-
-    # Only run if Terraform Plan succeeded with non-empty diff (changes present).
-    # Ref: https://developer.hashicorp.com/terraform/cli/commands/plan#detailed-exitcode
-    if: needs.terraform-plan.outputs.plan-exitcode == 2
-
+    if: needs.terraform-plan.outputs.upload-outcome == 'success'
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     defaults:


### PR DESCRIPTION
Only run Terraform Apply if Terraform Plan succeeded with non-empty diff (changes present).

Should save us some time as we'll no longer need to run apply when no changes expected.