### PR TITLE
feat(terraform)!: pass config between jobs

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -133,11 +133,10 @@ jobs:
 
           *Pusher: @$GITHUB_ACTOR, Action: \`$GITHUB_EVENT_NAME\`, Working Directory: \`$WORKING_DIRECTORY\`, Workflow: \`$GITHUB_WORKFLOW\`*" >> "$GITHUB_STEP_SUMMARY"
 
-      # Ref: https://www.redhat.com/sysadmin/encrypting-decrypting-7zip
       - name: Archive Terraform config
         run: |
           tar -cf terraform.tar .
-          7z a -p"$ENCRYPTION_PASSWORD" -mhe=on terraform.tar.7z terraform.tar
+          7z a -p"$ENCRYPTION_PASSWORD" terraform.tar.7z terraform.tar
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3
@@ -174,7 +173,7 @@ jobs:
       - name: Extract Terraform config
         run: |
           7z x -p"$ENCRYPTION_PASSWORD" terraform.tar.7z
-          tar xvf terraform.tar
+          tar -xf terraform.tar
 
       - name: Terraform Apply
         run: terraform apply -auto-approve -input=false tfplan


### PR DESCRIPTION
In the Plan job, Store Terraform plan in a file, archive entire Terraform configuration, then upload the archive to an artifact.

In the Apply job, download the artifact. This ensures that the plan generated during the Plan job is the actual plan to be applied, using the exact same providers and modules that were downloaded during the Plan job.

These changes are based on recommendations by HashiCorp (see comments in code for references).

Since the archive that is to be uploaded to an artifact contains the Plan file, which may contains sensitive information, the entire archive needs to be encrypted.

BREAKING CHANGE: add secret `ENCRYPTION_PASSWORD`