### PR TITLE
docs: specify how to pin actions versions

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -30,3 +30,19 @@
   - If a caller workflow has a job `provision` that calls the reusable workflow `terraform`, the final job will be named `provision / terraform`.
   - If a caller workflow has a job `build` that calls the reusable workflow `docker`, the final job will be named `build / docker`.
   - If a caller workflow has a job `deploy` that calls the reusable workflow `azure-webapp`, the final job will be named `deploy / azure-webapp`.
+
+## Actions
+
+- When using an action from a trusted GitHub organization (for example `actions`, `hashicorp`, `docker` or `Azure`), pin it to a specific release tag, for example:
+
+  ```yaml
+  - uses: actions/checkout@v3
+  ```
+
+  When using an action from an untrusted GitHub organization or a user, pin it to a specific commit SHA, for example:
+
+  ```yaml
+  - uses: GeekyEggo/delete-artifact@54ab544f12cdb7b71613a16a2b5a37a9ade990af
+    with:
+      name: my-artifact
+  ```


### PR DESCRIPTION
If #224 is merged with [this suggestion](https://github.com/equinor/ops-actions/pull/224#discussion_r1305306037), the documentation should be updated to specify how to use third-party actions in a secure manner.