### PR TITLE
fix(terraform): unable to delete artifact

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -46,8 +46,8 @@ concurrency:
   group: terraform @ ${{ inputs.working_directory }}
   cancel-in-progress: false
 
+# Set permissions required to login to Azure using OIDC.
 permissions:
-  # Set permissions required to login to Azure using OIDC.
   id-token: write
   contents: read
 


### PR DESCRIPTION
The implementation from #224 doesn't work in practice.

Switching over to the existing action discussed [here](https://github.com/equinor/ops-actions/pull/224#discussion_r1305306037). According to [this issue](https://github.com/GeekyEggo/delete-artifact/issues/13#issuecomment-1483925157), said action uses a hidden environment variable `ACTIONS_RUNTIME_TOKEN` to gain permission to delete artifacts. Our implementation relied on environment variable `GITHUB_TOKEN` which does not seem to have the required access.

#225 should be reopened and merged as well.