### PR TITLE
refactor(terraform): rename jobs

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -68,7 +68,7 @@ env:
   ENCRYPTION_PASSWORD: ${{ secrets.ENCRYPTION_PASSWORD }}
 
 jobs:
-  tf-plan:
+  tfplan:
     runs-on: ubuntu-latest
 
     # Run Terraform Plan in a separate "no operation" (noop) environment.
@@ -159,9 +159,9 @@ jobs:
           # Ref: https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#usage-limits
           retention-days: 35
 
-  tf-apply:
-    needs: tf-plan
-    if: needs.tf-plan.outputs.upload-outcome == 'success'
+  tfapply:
+    needs: tfplan
+    if: needs.tfplan.outputs.upload-outcome == 'success'
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     defaults:


### PR DESCRIPTION
Use shorter job names to prevent truncation.

For example, if the caller workflow has a job `deploy-dev` with display name `Deploy to dev`, then the resulting jobs would be called `Deploy to dev / Terraform Plan` and `Deploy to dev / Terraform Apply.`

These job names are too long to be displayed in full:

![image](https://github.com/equinor/ops-actions/assets/46495473/55ed34a3-f589-424c-8f15-e7eacfba0ff3)

Shorten the job names to prevent this:

![image](https://github.com/equinor/ops-actions/assets/46495473/1ef8d7eb-2d4b-4f09-9050-19d5a2939c3e)

