### PR TITLE
docs: update OIDC scripts usage

### DIFF
--- a/scripts/oidc/README.md
+++ b/scripts/oidc/README.md
@@ -10,44 +10,33 @@ It will:
 1. Create Azure role assignments for the service principal
 1. Set GitHub secrets `AZURE_CLIENT_ID`, `AZURE_SUBSCRIPTION_ID` and `AZURE_TENANT_ID`
 
-The script accepts the following arguments:
-
-1. The name of the Azure AD application to create
-1. The GitHub repository to configure OIDC for
-1. The path of the JSON file containing the OIDC configuration
-
 ## Configuration specification
 
 Example configuration:
 
 ```json
 {
+  "appName": "my-app",
   "federatedCredentials": [
     {
       "name": "deploy-dev",
-      "subject": "repo:${REPO}:environment:dev",
+      "subject": "repo:my-org/my-repo:environment:dev",
       "description": "Deploy to dev environment"
     }
   ],
   "roleAssignments": [
     {
-      "scope": "/subscriptions/${SUBSCRIPTION_ID}",
+      "scope": "/subscriptions/00000000-0000-0000-0000-000000000000",
       "role": "Contributor"
     }
   ]
 }
 ```
 
-> **Note**
->
-> `.federatedCredentials[].subject` must start with `repo:${REPO}:`.
->
-> `.roleAssignments[].scope` must start with `/subscriptions/${SUBSCRIPTION_ID}`.
-
 ## Prerequisites
 
 - [Install Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) (latest version as of writing: `2.49.0`) - to create Azure AD application, federated credentials, service principal and Azure role assignments
-- [Install GitHub CLI](https://cli.github.com) (latest version as of writing: `2.30.0`) - to create GitHub secrets
+- [Install GitHub CLI](https://cli.github.com) (latest version as of writing: `2.30.0`) - to set GitHub secrets
 - [Install jq](https://stedolan.github.io/jq/download/) (latest version as of writing: `1.6`) - to parse JSON config file
 - Activate Azure AD role `Application Developer` - to create Azure AD application, federated credentials and service principal
 - Activate Azure role `Owner` - to create Azure role assignments
@@ -63,12 +52,6 @@ Example configuration:
     az login
     ```
 
-1. Set Azure subscription:
-
-    ```console
-    az account set -s {SUBSCRIPTION_NAME_OR_ID}
-    ```
-
 1. Login to GitHub:
 
     ```console
@@ -80,13 +63,13 @@ Example configuration:
 1. Run the script `oidc.sh`:
 
     ```console
-    ./oidc.sh {APP_NAME} {REPO} {CONFIG_FILE}
+    ./oidc.sh {CONFIG_FILE}
     ```
 
     For example:
 
     ```console
-    ./oidc.sh my-app my-org/my-repo ./oidc.json
+    ./oidc.sh oidc.json
     ```
 
 ## References


### PR DESCRIPTION
I've updated the OIDC script usage to represent how I want the script usage to be.

The script still needs to be updated to reflect the documentation.

The idea is to remove the use of the environment variables `REPO` and `SUBSCRIPTION_ID`, in order to allow configuration of multiple repos and subscriptions for a single service principal.