### PR TITLE
chore: write OIDC GitHub scopes to stdout

### DIFF
--- a/scripts/oidc/oidc.sh
+++ b/scripts/oidc/oidc.sh
@@ -171,6 +171,15 @@ do
   repo=$(cut -d : -f 1 <<< "$scope")
   env=$(cut -d : -f 2 <<< "$scope")
 
+  if [[ -n "$env" ]]
+  then
+    level="environment '$env'"
+  else
+    level="repository"
+  fi
+
+  echo "Setting secrets for GitHub repository '$repo' at $level level."
+
   gh secret set "AZURE_CLIENT_ID" \
     --repo "$repo" \
     --env "$env" \


### PR DESCRIPTION
Write a message to stdout to specify at which level the script is setting GitHub secrets.