### PR TITLE
chore: set OIDC GitHub secrets at correct scope

### DIFF
--- a/scripts/oidc/oidc.sh
+++ b/scripts/oidc/oidc.sh
@@ -169,7 +169,7 @@ done
 # Set GitHub repository secrets
 ################################################################################
 
-if [[ "$repo_level" ]]
+if [[ "$repo_level" == true ]]
 then
   echo "Setting GitHub repository secrets..."
 


### PR DESCRIPTION
Prevent secrets from always being created at repository level.

Fixes #246