### PR TITLE
feat(terraform): plan job deploys temporarily

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -71,9 +71,6 @@ jobs:
   terraform-plan:
     name: Terraform Plan
     runs-on: ubuntu-latest
-
-    # Run Terraform Plan in a separate "no operation" (noop) environment.
-    # This allows Terraform Plan to run without requiring a manual approval.
     environment: ${{ inputs.environment }}
 
     defaults:


### PR DESCRIPTION
Remove use of `noop` environment. As a result, GitHub will display the plan job as a "temporary deployment" to the given environment.

This effectively puts the plan job behind the same protection gates as the apply job, securing the workflow further.