### PR TITLE
feat(terraform): ensure use of open-source release

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -56,7 +56,7 @@ permissions:
 env:
   # Ensure use of open-source Terraform versions.
   # (versions 1.6.0 and above are source-available)
-  TERRAFORM_VERSION: "${{ inputs.terraform_version }} <1.5.0"
+  TERRAFORM_VERSION: "${{ inputs.terraform_version }} <1.6.0"
 
   # Configure Terraform to run in automation.
   # Makes output more consistent and less confusing in workflows where users don't directly execute Terraform commands.


### PR DESCRIPTION
Pin Terraform version to 1.5 and below, to ensure use of open-source release.