### PR TITLE
fix(terraform): use latest 1.5 patch version

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -18,7 +18,7 @@ on:
         description: The version of Terraform to install.
         type: string
         required: false
-        default: latest
+        default: ~1.5.0
 
       artifact_name:
         description: The name of the artifact to upload.


### PR DESCRIPTION
`latest` will automatically download `1.6` and above once it becomes available.

Set default version to latest `1.5` patch version to prevent this.