### PR TITLE
fix(terraform): Bash throws error if plan too long

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -114,8 +114,8 @@ jobs:
         id: plan
         run: terraform plan -no-color -input=false -out=tfplan -detailed-exitcode
 
-      # The stdout of the plan step must not be set in an intermediate environment variable,
-      # as long environment variables will cause Bash to throw an error "Argument list too long" on startup.
+      # The stdout of the plan step must not be set in an intermediate environment variable.
+      # Long environment variables will cause Bash to throw an error "Argument list too long" on startup.
       - name: Create job summary
         if: success() || failure()
         env:


### PR DESCRIPTION
If the generated execution plan is large enough, it results in an error when trying to store it in an intermediate environment variable.

To prevent this, treat outputs from Terraform commands as trusted, and reference them directly in inline Bash scripts.