### PR TITLE
chore: set cross tenant replication to false

### DIFF
--- a/scripts/terraform-backend/terraform-backend.sh
+++ b/scripts/terraform-backend/terraform-backend.sh
@@ -24,6 +24,7 @@ storage_account_id="$(az storage account create \
   --min-tls-version TLS1_2 \
   --allow-blob-public-access false \
   --allow-shared-key-access false \
+  --allow-cross-tenant-replication false \
   --query id \
   --output tsv)"
 


### PR DESCRIPTION
CrossTenant replication is not allowed in Omnia Classic L2
