### PR TITLE
revert(dotnet): add optional input `runs_on`

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -67,6 +67,8 @@ on:
 
 jobs:
   dotnet:
+    # The steps for this job assume that OS is Ubuntu.
+    # Use the "runtime" input to specify target OS and architecture instead.
     runs-on: ubuntu-latest
     env:
       CI: ${{ inputs.ci }}


### PR DESCRIPTION
Steps have been written with the assumption that runner OS is Ubuntu.

Running this workflow on a Windows runner have been throwing errors.

Refs: dd8620e