### PR TITLE
docs: update usage examples

### DIFF
--- a/docs/usage-examples.md
+++ b/docs/usage-examples.md
@@ -212,7 +212,7 @@ jobs:
     with:
       environment: development
       artifact_name: ${{ needs.build.outputs.artifact_name }}
-      app_name: app-example-dev
+      app_name: app-foobar-dev
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}


### PR DESCRIPTION
- Add note that you must pin to a specific version of the workflow.
- Remove most optional inputs from examples, as they should be as minimal as possible. Some optional inputs are still present, as I believe they increase the understanding of the examples.
- Add separate ACR and generic container registry examples.
- Update example values for most `*_version` inputs, pinning to latest minor versions.