### PR TITLE
docs: update OIDC README

### DIFF
--- a/scripts/oidc/README.md
+++ b/scripts/oidc/README.md
@@ -112,7 +112,6 @@ For example:
 - When adding, updating or removing federated credentials in the configuration file, you'll need to manually delete old federated credentials.
 - When adding, updating or removing role assignments in the configuration file, you'll need to manually delete old role assignments.
 
-
 ## References
 
 - [Microsoft Docs](https://docs.microsoft.com/en-us/azure/developer/github/connect-from-azure)


### PR DESCRIPTION
Small additions to the README:
- Adding link to the App Registration naming convention in cyclops-internal
- Maintenance after creating App Registration: adding Application Owners and CI reference (and where to find it)
- "Checklist" when updating the OIDC script: specifying that the OIDC script needs to be run again, and manually deleting the old versions in Azure