### PR TITLE
feat(super-linter): exclude files from linting

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -3,10 +3,19 @@ name: ♻ super-linter
 
 on:
   workflow_call:
+    inputs:
+      filter_regex_exclude:
+        description: Exclude files from linting using a regex pattern.
+        type: string
+        required: false
+        default: ""
 
 jobs:
   super-linter:
     runs-on: ubuntu-latest
+    env:
+      FILTER_REGEX_EXCLUDE: ${{ inputs.filter_regex_exclude }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
See super-linter envvars: https://github.com/super-linter/super-linter#environment-variables

Will be used to exclude auto generated docs from linting.