### PR TITLE
docs: correct scope for Terraform backend access

### DIFF
--- a/scripts/terraform-backend/README.md
+++ b/scripts/terraform-backend/README.md
@@ -66,7 +66,7 @@ Example configuration:
     ```json
     {
       "role": "Storage Blob Data Owner",
-      "scope": "/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/<RESOURCE_GROUP_NAME>/storageAccounts/<STORAGE_ACCOUNT_NAME>"
+      "scope": "/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/<RESOURCE_GROUP_NAME>/providers/Microsoft.Storage/storageAccounts/<STORAGE_ACCOUNT_NAME>"
     }
     ```
 


### PR DESCRIPTION
fix wrong scope in step 5 terraform backend guide as you will get an error saying the scope is invalid when running step.