### PR TITLE
fix(terraform): no job summary on error

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -142,6 +142,7 @@ jobs:
       # To bypass this, the plan must be explicitly read during this step using the "terraform show" command.
       - name: Create job summary
         if: success() || failure()
+        shell: bash {0}
         env:
           TF_FMT_OUTCOME: ${{ steps.fmt.outcome }}
           TF_INIT_OUTCOME: ${{ steps.init.outcome }}


### PR DESCRIPTION
Fix an issue where if an error occurs and no plan is generated, the `terraform show` command will throw an error and no job summary will be created.