### PR TITLE
chore: update dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,6 +4,3 @@ FROM mcr.microsoft.com/devcontainers/base:ubuntu-22.04
 RUN apt-get update && apt-get install --no-install-recommends -y bash-completion=1:2.11-5ubuntu1 \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
-
-# Required for Python scripts to find installed packages
-ENV PYTHONPATH="/usr/local/python/3.10.12/lib/python3.10/site-packages"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,6 +14,9 @@
       "version": "3.10.12"
     }
   },
+  "containerEnv": {
+    "PYTHONPATH": "/usr/local/python/current/lib/current/site-packages"
+  },
   "customizations": {
     "vscode": {
       "extensions": [


### PR DESCRIPTION
Set generic Python path, independent of installed Python version.
Simplifies future potential upgrades of Python.