### PR TITLE
feat(terraform): speed up archive step

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -174,7 +174,7 @@ jobs:
         if: steps.plan.outputs.exitcode == 2
         run: |
           tar -cf terraform.tar .
-          7z a -p"$ENCRYPTION_PASSWORD" terraform.tar.7z terraform.tar
+          7z a -mx=1 -p"$ENCRYPTION_PASSWORD" terraform.tar.7z terraform.tar
 
       - name: Upload artifact
         id: upload


### PR DESCRIPTION
Set compression to fastest method.

Local tests: slightly larger archive (~80 MB vs ~60 MB) but much faster process (~3 seconds vs ~30 seconds).

Workflow tests: slightly larger archive (~54 MB vs ~35 MB) but much faster process (~18 seconds vs 1 minute 5 seconds).