### PR TITLE
chore: update OIDC script

### DIFF
--- a/scripts/oidc/oidc.sh
+++ b/scripts/oidc/oidc.sh
@@ -26,9 +26,6 @@ case $response in
     ;;
 esac
 
-export REPO
-export SUBSCRIPTION_ID
-
 ################################################################################
 # Read OIDC configuration
 ################################################################################
@@ -40,6 +37,9 @@ else
   echo "Config file '$CONFIG_FILE' does not exist."
   exit 1
 fi
+
+export REPO
+export SUBSCRIPTION_ID
 
 config=$(envsubst < "$CONFIG_FILE")
 


### PR DESCRIPTION
Move exports to just before the config file is read. This should make it more clear that the exports are there to make their values available to the config file.