### PR TITLE
feat(terraform): set environment-specific artifact name by default

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -31,7 +31,7 @@ on:
         description: The name of the artifact to upload.
         type: string
         required: false
-        default: terraform
+        default: terraform-${{ inputs.environment }}
 
       runs_on:
         description: The label of the runner (GitHub- or self-hosted) to run this workflow on.


### PR DESCRIPTION
We usually call this reusable workflow for multiple environments per caller workflow.

To prevent having to set explicit artifact names for each job, set environment-specific artifact name by default.