### PR TITLE
fix(terraform): artifact already exists

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -83,7 +83,7 @@ env:
   ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
   ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
 
-  ARTIFACT_NAME: ${{ inputs.artifact_name || format("terraform-{0}", inputs.environment) }}
+  ARTIFACT_NAME: ${{ inputs.artifact_name || format('terraform-{0}', inputs.environment) }}
   ENCRYPTION_PASSWORD: ${{ secrets.ENCRYPTION_PASSWORD }}
 
 jobs:


### PR DESCRIPTION
Inputs can not refer to other inputs, so default artifact name must be generated in `env` context. 