### PR TITLE
chore: update Terraform backend script

### DIFF
--- a/scripts/terraform-backend/terraform-backend.sh
+++ b/scripts/terraform-backend/terraform-backend.sh
@@ -162,8 +162,6 @@ echo "Creating resource lock..."
 az resource lock create \
   --name 'Terraform' \
   --lock-type ReadOnly \
-  --resource-group "${RESOURCE_GROUP_NAME}" \
-  --resource-type "Microsoft.Storage/storageAccounts" \
-  --resource-name "${STORAGE_ACCOUNT_NAME}" \
+  --resource "${storage_account_id}" \
   --notes "Prevent changes to Terraform backend configuration" \
   --output none


### PR DESCRIPTION
The issues with `az role assignment create` and `az resource lock create` that were fixed in #386 have proven to be due to the default behavior of Git Bash, not due to this script itself. The fixes are then redundant.

Preventing this behavior in Git Bash is documented in PR #342 (thanks @nemanja-drobac ❤️). As a result, this PR should be merged after that PR.