### PR TITLE
ci: release on release branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release/**
 
 jobs:
   release-please:
@@ -12,3 +13,4 @@ jobs:
       - uses: google-github-actions/release-please-action@v4
         with:
           release-type: simple
+          target-branch: ${{ github.ref_name }}


### PR DESCRIPTION
I need to release a fix for v9.

What I've done:
- Configured branch protection rules for branches `release/**`
- Created a branch `release/v9`

Now I need to update the release workflow to allow me to trigger on changes to this branch ([ref](https://github.com/google-github-actions/release-please-action/blob/cc61a07e2da466bebbc19b3a7dd01d6aecb20d1e/README.md#supporting-multiple-release-branches)).