### PR TITLE
feat(mkdocs): build MkDocs static site

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -69,8 +69,8 @@ jobs:
         id: tar
         working-directory: ${{ env.SITE_DIR }}
         run: |
-          tarball="$RUNNER_TEMP/$ARTIFACT_NAME.tar"
-          tar -cvf "$tarball" .
+          tarball="$RUNNER_TEMP/$ARTIFACT_NAME.tar.gz"
+          tar -cvzf "$tarball" .
           echo "tarball=$tarball" >> "$GITHUB_OUTPUT"
 
       - name: Upload artifact


### PR DESCRIPTION
Alternative to `mkdocs-gh-pages.yml`. That workflow builds MkDocs then deploys directly to GitHub Pages. This workflow builds MkDocs then uploads it to an artifact which can be deployed wherever you want (GitHub Pages, Azure Static Web App, Radix).