### PR TITLE
revert(dotnet): disable CI mode

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -62,7 +62,6 @@ jobs:
     # Use the "runtime" input to specify target OS and architecture instead.
     runs-on: ubuntu-latest
     env:
-      CI: ${{ inputs.ci }}
       PROJECT: ${{ inputs.project }}
       CONFIGURATION: Release
       RUNTIME: ${{ inputs.runtime }}


### PR DESCRIPTION
Setting environment variable `CI` to false does not have any effect other than what diagnostics are sent to NPM ([ref](https://docs.npmjs.com/cli/v10/using-npm/registry#does-npm-send-any-information-about-me-back-to-the-registry)).

Refs: 3c9a702
