### PR TITLE
ci: lint PR title on edit

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches:
       - main
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
 
 jobs:
   lint-codebase:


### PR DESCRIPTION
By default, the `pull_request` event only triggers on `opened`, `synchronize` and `repoened` ([ref](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request)). Add the `edited` type to ensure PR titles are re-linted when edited.