### PR TITLE
fix(mkdocs): unable to deploy artifact to GitHub Pages

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -69,8 +69,8 @@ jobs:
         id: tar
         working-directory: ${{ env.SITE_DIR }}
         run: |
-          tarball="$RUNNER_TEMP/$ARTIFACT_NAME.tar.gz"
-          tar -cvzf "$tarball" .
+          tarball="$RUNNER_TEMP/$ARTIFACT_NAME.tar"
+          tar -cvf "$tarball" .
           echo "tarball=$tarball" >> "$GITHUB_OUTPUT"
 
       - name: Upload artifact


### PR DESCRIPTION
GitHub themselves state that an artifact to be deployed to GitHub Pages [must contain a `.tar.gz` file](https://github.com/actions/upload-pages-artifact?tab=readme-ov-file#artifact-validation):

![image](https://github.com/equinor/ops-actions/assets/46495473/09a59432-1a33-4c7f-a59a-16b9b958097b)

However I was unable to deploy artifacts uploaded by this workflow to GitHub Pages. After digging through GitHub's own code, I found that they actually [do **not** compress the `.tar` file](https://github.com/actions/upload-pages-artifact/blob/56afc609e74202658d3ffba0e8f6dda462b719fa/action.yml#L32).

![image](https://github.com/equinor/ops-actions/assets/46495473/522fa824-ed93-4c08-b82e-6813ef94a34d)

I tested this change and the artifact is now deployed successfully 🎉 