### PR TITLE
refactor(commitlint): remove checkout step

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -47,11 +47,6 @@ jobs:
     name: commitlint
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
No need to perform a checkout to retrieve commits when the commit message to lint is explicitly passed to the workflow using the `message` input.

Can verify that it's still working as expected by looking at the checks that run for this PR 🙂 