### PR TITLE
docs: clarify artifact best practices

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -77,7 +77,7 @@
 
   This will drastically improve upload performance, as the `actions/upload-artifact` action will only need to make a single request to the GitHub API to upload the tarball, instead of multiple requests to upload each individual file.
 
-  Workflows that download an artifact must extract the tarball:
+- Workflows that download an artifact must extract the tarball:
 
   ```yaml
   - name: Download artifact


### PR DESCRIPTION
- Updated phrasing to remove references to `zip`. Best practices should be focused on how we do things now, not how we did things in the past.
- Updated phrasing to enforce best practices instead of recommending best practices (i.e. "you must do this" instead of "you could do this").
- Split artifact best practices into three separate points:
  1. Add artifact name input
  2. Create tarball and upload artifact with given name
  3. Downlad artifact with given name and extract tarball
- Move artifact-related best practices to dedicated section.