### PR TITLE
chore: allow optional shared key access to Terraform Backend

### DIFF
--- a/scripts/terraform-backend/README.md
+++ b/scripts/terraform-backend/README.md
@@ -58,7 +58,7 @@ Example configuration:
 1. Run the script:
 
     ```console
-    ./terraform-backend.sh <CONFIG_FILE> <LOCATION> [<OBJECT_ID>] [<IP_ADDRESSES>]
+    ./terraform-backend.sh <CONFIG_FILE> <LOCATION> <OBJECT_ID> [<IP_ADDRESSES>]
     ```
 
     For example:

--- a/scripts/terraform-backend/terraform-backend.sh
+++ b/scripts/terraform-backend/terraform-backend.sh
@@ -4,7 +4,7 @@ set -eu
 
 CONFIG_FILE=${1:?"CONFIG_FILE is unset or null"}
 LOCATION=${2:?"LOCATION is unset or null"}
-OBJECT_ID=${3:-""}
+OBJECT_ID=${3:?"OBJECT_ID is unset or null"}
 IP_ADDRESSES=${4:-""}
 
 ################################################################################
@@ -106,8 +106,10 @@ az group create \
 echo "Creating storage account..."
 
 ALLOW_SHARED_KEY_ACCESS="false"
+ROLE="Storage Blob Data Owner"
 if [[ "${USE_AZUREAD_AUTH}" != "true" ]]; then
   ALLOW_SHARED_KEY_ACCESS="true"
+  ROLE="Reader and Data Access"
 fi
 
 DEFAULT_ACTION="Deny"
@@ -211,15 +213,13 @@ az storage account management-policy create \
 # Create Azure role assignment
 ################################################################################
 
-if [[ -n "${OBJECT_ID}" ]]; then
-  echo "Creating role assignment..."
+echo "Creating role assignment..."
 
-  az role assignment create \
-    --assignee "${OBJECT_ID}" \
-    --role "Storage Blob Data Owner" \
-    --scope "${STORAGE_ACCOUNT_ID}" \
-    --output none
-fi
+az role assignment create \
+  --assignee "${OBJECT_ID}" \
+  --role "${ROLE}" \
+  --scope "${STORAGE_ACCOUNT_ID}" \
+  --output none
 
 ################################################################################
 # Create Azure resource lock


### PR DESCRIPTION
If backend config file does not contain explicit configuration of Azure AD authorization, the script should enable the shared access key and give the a role that gives key access instead.