### PR TITLE
feat(docker): generate job summary

### DIFF
--- a/.github/workflows/docker-acr.yml
+++ b/.github/workflows/docker-acr.yml
@@ -90,6 +90,8 @@ jobs:
 
       - name: Build and push
         uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_NO_SUMMARY: false
         with:
           context: ${{ inputs.working_directory }}
           tags: ${{ env.IMAGE }},${{ env.IMAGE_LATEST }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -77,6 +77,8 @@ jobs:
 
       - name: Build and push
         uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_NO_SUMMARY: false
         with:
           context: ${{ inputs.working_directory }}
           tags: ${{ env.IMAGE }},${{ env.IMAGE_LATEST }}


### PR DESCRIPTION
`docker/build-push-action` version 6 introduced generation of a job summary for build jobs, similar to our Terraform workflow.

Version 6 was merged in #498.

According to the action [README](https://github.com/docker/build-push-action/tree/v6/?tab=readme-ov-file#environment-variables), you can use environment variable `DOCKER_BUILD_NO_SUMMARY` to control the generation of this job summary. Explicitly set it to `false` to always generate job summary.
