### PR TITLE
feat(azure-function): disable top level GitHub token permissions

### DIFF
--- a/.github/workflows/azure-function.yml
+++ b/.github/workflows/azure-function.yml
@@ -53,11 +53,9 @@ jobs:
     name: Azure Function
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
-
-    # Set permissions required to login to Azure using OIDC.
     permissions:
-      id-token: write
-      contents: read
+      contents: read  # Required to checkout the repository
+      id-token: write # Required to login to Azure using OIDC
 
     steps:
       - name: Download artifact

--- a/.github/workflows/azure-function.yml
+++ b/.github/workflows/azure-function.yml
@@ -46,6 +46,8 @@ on:
         description: The ID of the Azure tenant to deploy the package to.
         required: true
 
+permissions: {}
+
 jobs:
   azure-function:
     name: Azure Function


### PR DESCRIPTION
Disable all permissions at the top level, then enable required permissions at job level instead.