### PR TITLE
feat(azure-webapp): disable top level GitHub token permissions

### DIFF
--- a/.github/workflows/azure-webapp.yml
+++ b/.github/workflows/azure-webapp.yml
@@ -52,6 +52,8 @@ on:
         description: The ID of the Azure tenant containing the Azure Web App.
         required: true
 
+permissions: {}
+
 jobs:
   azure-webapp:
     name: Azure Web App

--- a/.github/workflows/azure-webapp.yml
+++ b/.github/workflows/azure-webapp.yml
@@ -63,10 +63,9 @@ jobs:
       name: ${{ inputs.environment }}
       url: ${{ steps.deploy.outputs.webapp-url }}
 
-    # Set permissions required to login to Azure using OIDC.
     permissions:
-      id-token: write
-      contents: read
+      contents: read  # Required to checkout the repository
+      id-token: write # Required to login to Azure using OIDC
 
     steps:
       - name: Download artifact


### PR DESCRIPTION
Disable all permissions at the top level, then enable required permissions at job level instead.