### PR TITLE
feat(dotnet): disable top level GitHub token permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -61,6 +61,8 @@ on:
         description: The name of the uploaded artifact containing the application.
         value: ${{ inputs.artifact_name }}
 
+permissions: {}
+
 jobs:
   dotnet:
     name: .NET

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -70,8 +70,7 @@ jobs:
     # Use the "runtime" input to specify target OS and architecture instead.
     runs-on: ubuntu-latest
     permissions:
-      # Set permissions required to checkout the repository
-      contents: read
+      contents: read # Required to checkout the repository
 
     env:
       PROJECT: ${{ inputs.project }}

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -69,6 +69,10 @@ jobs:
     # The steps for this job assume that OS is Ubuntu.
     # Use the "runtime" input to specify target OS and architecture instead.
     runs-on: ubuntu-latest
+    permissions:
+      # Set permissions required to checkout the repository
+      contents: read
+
     env:
       PROJECT: ${{ inputs.project }}
       CONFIGURATION: Release


### PR DESCRIPTION
Disable all permissions at the top level, then enable required permissions at job level instead.