### PR TITLE
feat(mkdocs): disable top level GitHub token permissions

### DIFF
--- a/.github/workflows/mkdocs-gh-pages.yml
+++ b/.github/workflows/mkdocs-gh-pages.yml
@@ -27,13 +27,14 @@ on:
         required: false
         default: ""
 
+permissions: {}
+
 jobs:
   mkdocs:
     name: MkDocs
     runs-on: ubuntu-latest
-
     permissions:
-      contents: write
+      contents: write # Required to checkout the repository push to the "gh-pages" branch
 
     steps:
       - name: Checkout

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -32,10 +32,15 @@ on:
         description: The name of the uploaded artifact containing the site.
         value: ${{ inputs.artifact_name }}
 
+permissions: {}
+
 jobs:
   mkdocs:
     name: MkDocs
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to checkout the repository
+
     env:
       SITE_DIR: site
       ARTIFACT_NAME: ${{ inputs.artifact_name }}


### PR DESCRIPTION
Disable all permissions at the top level, then enable required permissions at job level instead.