### PR TITLE
feat(python): disable top level GitHub token permissions

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -36,10 +36,14 @@ on:
         description: The name of the uploaded artifact containing the application.
         value: ${{ inputs.artifact_name }}
 
+permissions: {}
+
 jobs:
   python:
     name: Python
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to checkout the repository
 
     defaults:
       run:


### PR DESCRIPTION
Disable all permissions at the top level, then enable required permissions at job level instead. This is to ensure that we follow the principle of least privilege.