### PR TITLE
feat(semantic-release): disable top level GitHub token permissions

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -46,10 +46,15 @@ on:
         required: false
         default: latest
 
+permissions: {}
+
 jobs:
   semantic-release:
     name: semantic-release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to checkout the repository
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Disable all permissions at the top level, then enable required permissions at job level instead. This is to ensure that we follow the principle of least privilege.