### PR TITLE
feat(commitlint): disable top level GitHub token permissions

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -42,6 +42,8 @@ on:
         type: string
         required: false
 
+permissions: {}
+
 jobs:
   commitlint:
     name: commitlint


### PR DESCRIPTION
Disable all permissions at the top level, since no permissions are required. This is to ensure that we follow the principle of least privilege.