### PR TITLE
feat(super-linter): disable top level GitHub token permissions

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -15,10 +15,15 @@ on:
         required: false
         default: ""
 
+permissions: {}
+
 jobs:
   super-linter:
     name: Super-linter
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to checkout the repository
+
     env:
       FILTER_REGEX_EXCLUDE: ${{ inputs.filter_regex_exclude }}
       FILTER_REGEX_INCLUDE: ${{ inputs.filter_regex_include }}


### PR DESCRIPTION
Disable all permissions at the top level, then enable required permissions at job level instead. This is to ensure that we follow the principle of least privilege.