### PR TITLE
feat(terraform): skip job summary generation on empty plan

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -148,7 +148,7 @@ jobs:
       # Some plans are too large to be stored in environment variables or step outputs, resulting in an error.
       # To bypass this, the plan must be explicitly read during this step using the "terraform show" command.
       - name: Create job summary
-        if: success() || failure()
+        if: (success() || failure()) && steps.plan.outputs.exitcode != 0
         shell: bash {0}
         env:
           TF_FMT_OUTCOME: ${{ steps.fmt.outcome }}

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -148,7 +148,9 @@ jobs:
       # Some plans are too large to be stored in environment variables or step outputs, resulting in an error.
       # To bypass this, the plan must be explicitly read during this step using the "terraform show" command.
       - name: Create job summary
-        if: (success() || failure()) && steps.plan.outputs.exitcode != 0
+        # Only run if Terraform Plan succeeded with non-empty diff (changes present).
+        # Ref: https://developer.hashicorp.com/terraform/cli/commands/plan#detailed-exitcode
+        if: steps.plan.outputs.exitcode == 2
         shell: bash {0}
         env:
           TF_FMT_OUTCOME: ${{ steps.fmt.outcome }}
@@ -177,7 +179,6 @@ jobs:
       - name: Create tarball
         id: tar
         # Only run if Terraform Plan succeeded with non-empty diff (changes present).
-        # Ref: https://developer.hashicorp.com/terraform/cli/commands/plan#detailed-exitcode
         if: steps.plan.outputs.exitcode == 2
         run: |
           tarball="$RUNNER_TEMP/$ARTIFACT_NAME.tar.gpg"


### PR DESCRIPTION
Only generate job summary for plans containing actual changes. Saves time as you won't have to check for empty plans.