### PR TITLE
ci: disable top level GitHub token permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,8 @@ on:
       - synchronize
       - reopened
 
+permissions: {}
+
 jobs:
   lint-codebase:
     name: Lint codebase

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   release-please:
     name: Release Please

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ jobs:
   release-please:
     name: Release Please
     runs-on: ubuntu-latest
+    permissions:
+      contents: write      # Required to update changelog file
+      pull-requests: write # Required to create release PRs
     steps:
       - uses: googleapis/release-please-action@v4
         with:


### PR DESCRIPTION
Disable top level GitHub token permissions for non-reusable workflows used to automate tasks in this repository.