### PR TITLE
feat(super-linter): read configuration file

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -25,7 +25,7 @@ on:
         default: latest
 
       extends:
-        description: Newline-separated string of shareable configurations to extend.
+        description: Newline-separated string of shareable configurations to install.
         type: string
         required: false
         default: |-
@@ -48,7 +48,15 @@ jobs:
   commitlint:
     name: commitlint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to checkout the repository
+
     steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+        with:
+          fetch-depth: 0
+
       - name: Setup Node.js
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b
         with:


### PR DESCRIPTION
Checkout repository, allowing configuration file (`commitlint.config.js`) to be read by the workflow.