### PR TITLE
fix(super-linter): disable Checkov and JSCPD linters

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Lint Codebase
         uses: super-linter/super-linter@b92721f792f381cedc002ecdbb9847a15ece5bb8
         env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           VALIDATE_ALL_CODEBASE: false # Only validate new changes
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FILTER_REGEX_EXCLUDE: ${{ inputs.filter_regex_exclude }}

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -34,8 +34,7 @@ jobs:
       - name: Lint Codebase
         uses: super-linter/super-linter@b92721f792f381cedc002ecdbb9847a15ece5bb8
         env:
-          VALIDATE_ALL_CODEBASE: false
-          DEFAULT_BRANCH: main
+          VALIDATE_ALL_CODEBASE: false # Only validate new changes
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FILTER_REGEX_EXCLUDE: ${{ inputs.filter_regex_exclude }}
           FILTER_REGEX_INCLUDE: ${{ inputs.filter_regex_include }}

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Lint Codebase
         uses: super-linter/super-linter@b92721f792f381cedc002ecdbb9847a15ece5bb8
         env:
+          VALIDATE_ALL_CODEBASE: ${{ github.event_name != 'pull_request' }} # If PR, only validate changed files
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FILTER_REGEX_EXCLUDE: ${{ inputs.filter_regex_exclude }}
           FILTER_REGEX_INCLUDE: ${{ inputs.filter_regex_include }}

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -35,8 +35,11 @@ jobs:
         uses: super-linter/super-linter@b92721f792f381cedc002ecdbb9847a15ece5bb8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VALIDATE_ALL_CODEBASE: ${{ github.event_name != 'pull_request' }} # If PR, only validate changed files
           FILTER_REGEX_EXCLUDE: ${{ inputs.filter_regex_exclude }}
           FILTER_REGEX_INCLUDE: ${{ inputs.filter_regex_include }}
-          VALIDATE_CHECKOV: false # TODO(@hknutsen): exaplin why this is explicitly disabled
-          VALIDATE_JSCPD: false # TODO(@hknutsen): exaplin why this is explicitly disabled
+          # If PR, only validate changed files:
+          VALIDATE_ALL_CODEBASE: ${{ github.event_name != 'pull_request' }}
+          # Checkov and JSCPD ignore the above FILTER_REGEX_EXCLUDE, FILTER_REGEX_INCLUDE and VALIDATE_ALL_CODEBASE environment variables.
+          # Explicitly disable these linters to prevent them from being run when they should not:
+          VALIDATE_CHECKOV: false
+          VALIDATE_JSCPD: false

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -34,8 +34,6 @@ jobs:
       - name: Lint Codebase
         uses: super-linter/super-linter@b92721f792f381cedc002ecdbb9847a15ece5bb8
         env:
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-          VALIDATE_ALL_CODEBASE: false # Only validate new changes
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FILTER_REGEX_EXCLUDE: ${{ inputs.filter_regex_exclude }}
           FILTER_REGEX_INCLUDE: ${{ inputs.filter_regex_include }}

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -34,7 +34,9 @@ jobs:
       - name: Lint Codebase
         uses: super-linter/super-linter@b92721f792f381cedc002ecdbb9847a15ece5bb8
         env:
-          VALIDATE_ALL_CODEBASE: ${{ github.event_name != 'pull_request' }} # If PR, only validate changed files
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_ALL_CODEBASE: ${{ github.event_name != 'pull_request' }} # If PR, only validate changed files
           FILTER_REGEX_EXCLUDE: ${{ inputs.filter_regex_exclude }}
           FILTER_REGEX_INCLUDE: ${{ inputs.filter_regex_include }}
+          VALIDATE_CHECKOV: false # TODO(@hknutsen): exaplin why this is explicitly disabled
+          VALIDATE_JSCPD: false # TODO(@hknutsen): exaplin why this is explicitly disabled


### PR DESCRIPTION
Checkov and JSCPD linters ignore the `FILTER_REGEX_EXCLUDE`, `FILTER_REGEX_INCLUDE` and `VALIDATE_ALL_CODEBASE` environment variables. Explicitly disable these linters to prevent them from being run when they should not.