### PR TITLE
ci: set required permissions for jobs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,7 @@ jobs:
     name: Lint codebase
     uses: ./.github/workflows/super-linter.yml
     permissions:
+      contents: read
       statuses: write
     with:
       filter_regex_exclude: (.*CHANGELOG\.md$|docs/workflows/.*)

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,12 +10,13 @@ on:
       - synchronize
       - reopened
 
-permissions: {}
-
 jobs:
   lint-codebase:
     name: Lint codebase
     uses: ./.github/workflows/super-linter.yml
+    permissions:
+      contents: read
+      statuses: write
     with:
       filter_regex_exclude: (.*CHANGELOG\.md$|docs/workflows/.*)
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,12 +10,13 @@ on:
       - synchronize
       - reopened
 
+permissions: {}
+
 jobs:
   lint-codebase:
     name: Lint codebase
     uses: ./.github/workflows/super-linter.yml
     permissions:
-      contents: read
       statuses: write
     with:
       filter_regex_exclude: (.*CHANGELOG\.md$|docs/workflows/.*)

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,8 +10,6 @@ on:
       - synchronize
       - reopened
 
-permissions: {}
-
 jobs:
   lint-codebase:
     name: Lint codebase


### PR DESCRIPTION
Set required permissions for Super-linter job to run successfully.