### PR TITLE
chore: prettify OIDC script

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.sh]
+indent_style = space
+indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,3 @@
 [*.sh]
 indent_style = space
-indent_size = 4
+indent_size = 2

--- a/scripts/oidc/oidc.sh
+++ b/scripts/oidc/oidc.sh
@@ -5,8 +5,7 @@ set -eu
 CONFIG_FILE=${1:?"CONFIG_FILE is unset or null"}
 readonly CONFIG_FILE
 
-if [[ -f "$CONFIG_FILE" ]]
-then
+if [[ -f "$CONFIG_FILE" ]]; then
   echo "Using config file '$CONFIG_FILE'."
 else
   echo "Config file '$CONFIG_FILE' does not exist."

--- a/scripts/oidc/oidc.sh
+++ b/scripts/oidc/oidc.sh
@@ -77,7 +77,7 @@ done
 # Read OIDC configuration
 ################################################################################
 
-CONFIG=$(envsubst <"$CONFIG_FILE")
+CONFIG=$(envsubst < "$CONFIG_FILE")
 readonly CONFIG
 
 ################################################################################
@@ -132,7 +132,7 @@ readonly SP_ID
 # Create Azure AD application federated credentials
 ################################################################################
 
-readarray -t FICS <<<"$(echo "$CONFIG" | jq -c .federatedCredentials[])"
+readarray -t FICS <<< "$(echo "$CONFIG" | jq -c .federatedCredentials[])"
 readonly FICS
 
 repo_level=false        # Should OIDC be configured at the repository level?
@@ -186,7 +186,7 @@ done
 # Create Azure role assignments
 ################################################################################
 
-readarray -t ROLE_ASSIGNMENTS <<<"$(echo "$CONFIG" | jq -c .roleAssignments[])"
+readarray -t ROLE_ASSIGNMENTS <<< "$(echo "$CONFIG" | jq -c .roleAssignments[])"
 readonly ROLE_ASSIGNMENTS
 
 for role_assignment in "${ROLE_ASSIGNMENTS[@]}"; do

--- a/scripts/oidc/oidc.sh
+++ b/scripts/oidc/oidc.sh
@@ -56,7 +56,9 @@ TENANT_ID=$(echo "$ACCOUNT" | jq -j .tenantId)
 readonly TENANT_ID
 
 while true; do
-  read -r -p "Configure OIDC from GitHub repository '$REPO' to Azure subscription '$SUBSCRIPTION_NAME'? (y/N) " response
+  read -r -p "Configure OIDC from GitHub repository '$REPO' to
+Azure subscription '$SUBSCRIPTION_NAME'? (y/N) " response
+
   case "$response" in
   [yY][eE][sS] | [yY])
     echo "Proceeding with configuration..."

--- a/scripts/oidc/oidc.sh
+++ b/scripts/oidc/oidc.sh
@@ -55,7 +55,7 @@ TENANT_ID=$(echo "$ACCOUNT" | jq -j .tenantId)
 readonly TENANT_ID
 
 while true; do
-  read -r -p "Configure OIDC from GitHub repository '$REPO' to
+  read -r -p "Configure OIDC from GitHub repository '$REPO' to \
 Azure subscription '$SUBSCRIPTION_NAME'? (y/N) " response
 
   case "$response" in

--- a/scripts/oidc/oidc.sh
+++ b/scripts/oidc/oidc.sh
@@ -19,12 +19,12 @@ cd "$(dirname "$CONFIG_FILE")"
 ################################################################################
 
 hash az 2>/dev/null || {
-  echo -e "\nERROR: Azure-CLI not found in PATH. Exiting... " >&2
+  echo -e "\nERROR: Azure CLI not found in PATH. Exiting... " >&2
   exit 1
 }
 
 hash gh 2>/dev/null || {
-  echo -e "\nERROR: Github-CLI not found in PATH. Exiting... " >&2
+  echo -e "\nERROR: GitHub CLI not found in PATH. Exiting... " >&2
   exit 1
 }
 

--- a/scripts/oidc/oidc.sh
+++ b/scripts/oidc/oidc.sh
@@ -77,7 +77,7 @@ done
 # Read OIDC configuration
 ################################################################################
 
-CONFIG=$(envsubst < "$CONFIG_FILE")
+CONFIG=$(envsubst <"$CONFIG_FILE")
 readonly CONFIG
 
 ################################################################################
@@ -132,7 +132,7 @@ readonly SP_ID
 # Create Azure AD application federated credentials
 ################################################################################
 
-readarray -t FICS <<< "$(echo "$CONFIG" | jq -c .federatedCredentials[])"
+readarray -t FICS <<<"$(echo "$CONFIG" | jq -c .federatedCredentials[])"
 readonly FICS
 
 repo_level=false        # Should OIDC be configured at the repository level?
@@ -186,7 +186,7 @@ done
 # Create Azure role assignments
 ################################################################################
 
-readarray -t ROLE_ASSIGNMENTS <<< "$(echo "$CONFIG" | jq -c .roleAssignments[])"
+readarray -t ROLE_ASSIGNMENTS <<<"$(echo "$CONFIG" | jq -c .roleAssignments[])"
 readonly ROLE_ASSIGNMENTS
 
 for role_assignment in "${ROLE_ASSIGNMENTS[@]}"; do


### PR DESCRIPTION
Trying to prettify the OIDC script a bit to make it slightly more pleasant to work in and with.

- Use uppercase for environment variables and constants.
- Use lowercase for local variables.
- Set environment variables and constants to read-only as soon as possible.
- Only wrap variable references with `{}` if required.
- Don't exceed 80 character line limit.