### PR TITLE
chore: prettify Terraform backend script

### DIFF
--- a/scripts/oidc/oidc.sh
+++ b/scripts/oidc/oidc.sh
@@ -11,7 +11,6 @@ else
   echo "Config file '$CONFIG_FILE' does not exist."
   exit 1
 fi
-
 cd "$(dirname "$CONFIG_FILE")"
 
 ################################################################################
@@ -94,7 +93,6 @@ APP_ID=$(az ad app list \
 
 if [[ -z "$APP_ID" ]]; then
   echo "Creating application..."
-
   APP_ID=$(az ad app create \
     --display-name "$APP_NAME" \
     --sign-in-audience AzureADMyOrg \
@@ -103,7 +101,6 @@ if [[ -z "$APP_ID" ]]; then
 else
   echo "Using existing application."
 fi
-
 readonly APP_ID
 
 ################################################################################
@@ -117,7 +114,6 @@ SP_ID=$(az ad sp list \
 
 if [[ -z "$SP_ID" ]]; then
   echo "Creating service principal..."
-
   SP_ID=$(az ad sp create \
     --id "$APP_ID" \
     --query id \
@@ -125,7 +121,6 @@ if [[ -z "$SP_ID" ]]; then
 else
   echo "Using existing service principal."
 fi
-
 readonly SP_ID
 
 ################################################################################
@@ -156,14 +151,12 @@ for fic in "${FICS[@]}"; do
 
   if [[ -z "$fic_id" ]]; then
     echo "Creating federated identity credential '$fic_name'..."
-
     az ad app federated-credential create \
       --id "$APP_ID" \
       --parameters "$parameters" \
       --output none
   else
     echo "Updating existing federated identity credential '$fic_name'..."
-
     az ad app federated-credential update \
       --id "$APP_ID" \
       --federated-credential-id "$fic_id" \
@@ -200,7 +193,6 @@ for role_assignment in "${ROLE_ASSIGNMENTS[@]}"; do
   fi
 
   echo "Assigning role '$role' at scope '$scope'..."
-
   az role assignment create \
     --role "$role" \
     --assignee-object-id "$SP_ID" \

--- a/scripts/oidc/oidc.sh
+++ b/scripts/oidc/oidc.sh
@@ -57,24 +57,17 @@ export SUBSCRIPTION_ID
 TENANT_ID=$(echo "$ACCOUNT" | jq -j .tenantId)
 readonly TENANT_ID
 
-while true; do
-  read -r -p "Configure OIDC from GitHub repository '$REPO' to \
+read -r -p "Configure OIDC from GitHub repository '$REPO' to \
 Azure subscription '$SUBSCRIPTION_NAME'? (y/N) " response
-
-  case "$response" in
+case "$response" in
   [yY][eE][sS] | [yY])
     echo "Proceeding with configuration..."
-    break
     ;;
-  [nN][oO] | [nN])
+  *)
     echo "Exiting without configuring..."
     exit 0
     ;;
-  *)
-    echo "Invalid input, please type 'y' or 'n'."
-    ;;
-  esac
-done
+esac
 
 ################################################################################
 # Read OIDC configuration

--- a/scripts/oidc/oidc.sh
+++ b/scripts/oidc/oidc.sh
@@ -135,7 +135,6 @@ declare -A environments # Environments to configure OIDC for.
 
 for fic in "${FICS[@]}"; do
   fic_name=$(echo "$fic" | jq -j .name)
-
   fic_id=$(az ad app federated-credential list \
     --id "$APP_ID" \
     --query "[?name == '$fic_name'].id" \
@@ -166,7 +165,6 @@ for fic in "${FICS[@]}"; do
 
   subject=$(echo "$fic" | jq -j .subject)
   entity_type=$(echo "$subject" | cut -d : -f 3)
-
   if [[ "$entity_type" == "environment" ]]; then
     env=$(echo "$subject" | cut -d : -f 4)
     environments[$env]=true
@@ -208,13 +206,10 @@ done
 
 if [[ "$repo_level" == true ]]; then
   echo "Setting GitHub repository secrets..."
-
   gh secret set "AZURE_CLIENT_ID" \
     --body "$APP_ID"
-
   gh secret set "AZURE_SUBSCRIPTION_ID" \
     --body "$SUBSCRIPTION_ID"
-
   gh secret set "AZURE_TENANT_ID" \
     --body "$TENANT_ID"
 fi
@@ -225,15 +220,12 @@ fi
 
 for env in "${!environments[@]}"; do
   echo "Setting GitHub environment secrets for environment '$env'..."
-
   gh secret set "AZURE_CLIENT_ID" \
     --env "$env" \
     --body "$APP_ID"
-
   gh secret set "AZURE_SUBSCRIPTION_ID" \
     --env "$env" \
     --body "$SUBSCRIPTION_ID"
-
   gh secret set "AZURE_TENANT_ID" \
     --env "$env" \
     --body "$TENANT_ID"

--- a/scripts/oidc/oidc.sh
+++ b/scripts/oidc/oidc.sh
@@ -5,10 +5,14 @@ set -eu
 CONFIG_FILE=${1:?"CONFIG_FILE is unset or null"}
 readonly CONFIG_FILE
 
+error() {
+  echo -e "\033[0;31mERROR: $*\033[0;37m" >&2
+}
+
 if [[ -f "$CONFIG_FILE" ]]; then
   echo "Using config file '$CONFIG_FILE'."
 else
-  echo "Config file '$CONFIG_FILE' does not exist."
+  error "Config file '$CONFIG_FILE' does not exist."
   exit 1
 fi
 cd "$(dirname "$CONFIG_FILE")"
@@ -18,17 +22,17 @@ cd "$(dirname "$CONFIG_FILE")"
 ################################################################################
 
 hash az 2>/dev/null || {
-  echo -e "\nERROR: Azure CLI not found in PATH. Exiting... " >&2
+  error "Azure CLI not found in PATH."
   exit 1
 }
 
 hash gh 2>/dev/null || {
-  echo -e "\nERROR: GitHub CLI not found in PATH. Exiting... " >&2
+  error "GitHub CLI not found in PATH."
   exit 1
 }
 
 hash jq 2>/dev/null || {
-  echo -e "\nERROR: jq not found in PATH. Exiting... " >&2
+  error "jq not found in PATH."
   exit 1
 }
 

--- a/scripts/terraform-backend/terraform-backend.sh
+++ b/scripts/terraform-backend/terraform-backend.sh
@@ -18,10 +18,6 @@ error() {
   echo -e "\033[0;31mERROR: $*\033[0;37m" >&2
 }
 
-info() {
-  echo -e "\033[0;33mINFO: $*\033[0;37m"
-}
-
 ################################################################################
 # Verify installation of necessary software components
 ################################################################################
@@ -103,8 +99,8 @@ fi
 readonly LOCK_ID
 
 if [[ -n "$LOCK_ID" ]]; then
-  info "Storage account is locked."
-  info "Please remove the lock by running the following command:"
+  error "Storage account is locked. \
+Please remove the lock by running the following command:"
   echo -e "\n\033[0;36maz resource lock delete --ids $LOCK_ID\033[0m\n"
   exit 1
 fi

--- a/scripts/terraform-backend/terraform-backend.sh
+++ b/scripts/terraform-backend/terraform-backend.sh
@@ -36,8 +36,8 @@ SUBSCRIPTION_NAME=$(az account show --query name --output tsv)
 readonly SUBSCRIPTION_NAME
 
 while true; do
-  read -r -p "Create Terraform backend in Azure subscription '${SUBSCRIPTION_NAME}'? (y/N) " response
-  case "${response}" in
+  read -r -p "Create Terraform backend in Azure subscription '$SUBSCRIPTION_NAME'? (y/N) " response
+  case "$response" in
   [yY][eE][sS] | [yY])
     echo "Proceeding with creation..."
     break
@@ -56,26 +56,26 @@ done
 # Read Terraform backend configuration
 ################################################################################
 
-if [[ -f "${CONFIG_FILE}" ]]; then
-  echo "Using config file '${CONFIG_FILE}'."
+if [[ -f "$CONFIG_FILE" ]]; then
+  echo "Using config file '$CONFIG_FILE'."
 else
-  echo "Config file '${CONFIG_FILE}' does not exist."
+  echo "Config file '$CONFIG_FILE' does not exist."
   exit 1
 fi
 
-CONFIG=$(cat "${CONFIG_FILE}")
+CONFIG=$(cat "$CONFIG_FILE")
 readonly CONFIG
 
-RESOURCE_GROUP_NAME=$(echo "${CONFIG}" | jq -r .resource_group_name)
+RESOURCE_GROUP_NAME=$(echo "$CONFIG" | jq -r .resource_group_name)
 readonly RESOURCE_GROUP_NAME
 
-STORAGE_ACCOUNT_NAME=$(echo "${CONFIG}" | jq -r .storage_account_name)
+STORAGE_ACCOUNT_NAME=$(echo "$CONFIG" | jq -r .storage_account_name)
 readonly STORAGE_ACCOUNT_NAME
 
-CONTAINER_NAME=$(echo "${CONFIG}" | jq -r .container_name)
+CONTAINER_NAME=$(echo "$CONFIG" | jq -r .container_name)
 readonly CONTAINER_NAME
 
-USE_AZUREAD_AUTH=$(echo "${CONFIG}" | jq -r .use_azuread_auth)
+USE_AZUREAD_AUTH=$(echo "$CONFIG" | jq -r .use_azuread_auth)
 readonly USE_AZUREAD_AUTH
 
 ################################################################################
@@ -83,8 +83,8 @@ readonly USE_AZUREAD_AUTH
 ################################################################################
 
 STORAGE_ACCOUNT_ID=$(az storage account list \
-  --resource-group "${RESOURCE_GROUP_NAME}" \
-  --query "[?name == '${STORAGE_ACCOUNT_NAME}'].id" \
+  --resource-group "$RESOURCE_GROUP_NAME" \
+  --query "[?name == '$STORAGE_ACCOUNT_NAME'].id" \
   --output tsv)
 
 LOCK_NAME="Terraform"
@@ -93,16 +93,16 @@ readonly LOCK_NAME
 LOCK_ID=""
 if [[ -n "$STORAGE_ACCOUNT_ID" ]]; then
   LOCK_ID=$(az resource lock list \
-    --resource "${STORAGE_ACCOUNT_ID}" \
-    --query "[?name == '${LOCK_NAME}'].id" \
+    --resource "$STORAGE_ACCOUNT_ID" \
+    --query "[?name == '$LOCK_NAME'].id" \
     --output tsv)
 fi
 readonly LOCK_ID
 
-if [[ -n "${LOCK_ID}" ]]; then
+if [[ -n "$LOCK_ID" ]]; then
   echo -e "\n\033[0;33mStorage account is locked."
   echo -e "Please remove the lock by running the following command:"
-  echo -e "\n\033[0;36maz resource lock delete --ids ${LOCK_ID}\033[0m\n"
+  echo -e "\n\033[0;36maz resource lock delete --ids $LOCK_ID\033[0m\n"
   exit 1
 fi
 
@@ -113,8 +113,8 @@ fi
 echo "Creating resource group..."
 
 az group create \
-  --name "${RESOURCE_GROUP_NAME}" \
-  --location "${LOCATION}" \
+  --name "$RESOURCE_GROUP_NAME" \
+  --location "$LOCATION" \
   --output none
 
 ################################################################################
@@ -125,7 +125,7 @@ echo "Creating storage account..."
 
 ALLOW_SHARED_KEY_ACCESS="false"
 ROLE="Storage Blob Data Owner"
-if [[ "${USE_AZUREAD_AUTH}" != "true" ]]; then
+if [[ "$USE_AZUREAD_AUTH" != "true" ]]; then
   ALLOW_SHARED_KEY_ACCESS="true"
   ROLE="Reader and Data Access"
 fi
@@ -133,38 +133,38 @@ readonly ALLOW_SHARED_KEY_ACCESS
 readonly ROLE
 
 DEFAULT_ACTION="Deny"
-if [[ -z "${IP_ADDRESSES}" ]]; then
+if [[ -z "$IP_ADDRESSES" ]]; then
   DEFAULT_ACTION="Allow"
 fi
 readonly DEFAULT_ACTION
 
 STORAGE_ACCOUNT_ID="$(az storage account create \
-  --name "${STORAGE_ACCOUNT_NAME}" \
-  --resource-group "${RESOURCE_GROUP_NAME}" \
-  --location "${LOCATION}" \
+  --name "$STORAGE_ACCOUNT_NAME" \
+  --resource-group "$RESOURCE_GROUP_NAME" \
+  --location "$LOCATION" \
   --sku Standard_GRS \
   --access-tier Hot \
   --kind StorageV2 \
   --https-only true \
   --min-tls-version TLS1_2 \
   --allow-blob-public-access false \
-  --allow-shared-key-access "${ALLOW_SHARED_KEY_ACCESS}" \
+  --allow-shared-key-access "$ALLOW_SHARED_KEY_ACCESS" \
   --allow-cross-tenant-replication false \
-  --default-action "${DEFAULT_ACTION}" \
+  --default-action "$DEFAULT_ACTION" \
   --query id \
   --output tsv)"
 
 for ip_address in $IP_ADDRESSES; do
   az storage account network-rule add \
-    --account-name "${STORAGE_ACCOUNT_NAME}" \
-    --resource-group "${RESOURCE_GROUP_NAME}" \
-    --ip-address "${ip_address}" \
+    --account-name "$STORAGE_ACCOUNT_NAME" \
+    --resource-group "$RESOURCE_GROUP_NAME" \
+    --ip-address "$ip_address" \
     --output none
 done
 
 az storage account blob-service-properties update \
-  --account-name "${STORAGE_ACCOUNT_NAME}" \
-  --resource-group "${RESOURCE_GROUP_NAME}" \
+  --account-name "$STORAGE_ACCOUNT_NAME" \
+  --resource-group "$RESOURCE_GROUP_NAME" \
   --enable-delete-retention true \
   --delete-retention-days 30 \
   --enable-container-delete-retention true \
@@ -174,8 +174,8 @@ az storage account blob-service-properties update \
   --output none
 
 az security atp storage update \
-  --storage-account "${STORAGE_ACCOUNT_NAME}" \
-  --resource-group "${RESOURCE_GROUP_NAME}" \
+  --storage-account "$STORAGE_ACCOUNT_NAME" \
+  --resource-group "$RESOURCE_GROUP_NAME" \
   --is-enabled true \
   --output none
 
@@ -186,8 +186,8 @@ az security atp storage update \
 echo "Creating storage container..."
 
 az storage container create \
-  --name "${CONTAINER_NAME}" \
-  --account-name "${STORAGE_ACCOUNT_NAME}" \
+  --name "$CONTAINER_NAME" \
+  --account-name "$STORAGE_ACCOUNT_NAME" \
   --auth-mode login \
   --output none
 
@@ -197,7 +197,7 @@ az storage container create \
 
 echo "Creating lifecycle policy..."
 
-MANAGEMENT_POLICY=$(echo "${CONFIG}" | jq '{
+MANAGEMENT_POLICY=$(echo "$CONFIG" | jq '{
   rules: [
     {
       name: "Delete old tfstate versions",
@@ -226,9 +226,9 @@ MANAGEMENT_POLICY=$(echo "${CONFIG}" | jq '{
 readonly MANAGEMENT_POLICY
 
 az storage account management-policy create \
-  --account-name "${STORAGE_ACCOUNT_NAME}" \
-  --resource-group "${RESOURCE_GROUP_NAME}" \
-  --policy "${MANAGEMENT_POLICY}" \
+  --account-name "$STORAGE_ACCOUNT_NAME" \
+  --resource-group "$RESOURCE_GROUP_NAME" \
+  --policy "$MANAGEMENT_POLICY" \
   --output none
 
 ################################################################################
@@ -238,9 +238,9 @@ az storage account management-policy create \
 echo "Creating role assignment..."
 
 az role assignment create \
-  --assignee "${OBJECT_ID}" \
-  --role "${ROLE}" \
-  --scope "${STORAGE_ACCOUNT_ID}" \
+  --assignee "$OBJECT_ID" \
+  --role "$ROLE" \
+  --scope "$STORAGE_ACCOUNT_ID" \
   --output none
 
 ################################################################################
@@ -250,8 +250,8 @@ az role assignment create \
 echo "Creating resource lock..."
 
 az resource lock create \
-  --name "${LOCK_NAME}" \
+  --name "$LOCK_NAME" \
   --lock-type ReadOnly \
-  --resource "${STORAGE_ACCOUNT_ID}" \
+  --resource "$STORAGE_ACCOUNT_ID" \
   --notes "Prevent changes to Terraform backend configuration" \
   --output none

--- a/scripts/terraform-backend/terraform-backend.sh
+++ b/scripts/terraform-backend/terraform-backend.sh
@@ -46,13 +46,13 @@ readonly SUBSCRIPTION_NAME
 read -r -p "Create Terraform backend in \
 Azure subscription '$SUBSCRIPTION_NAME'? (y/N) " response
 case "$response" in
-  [yY][eE][sS] | [yY])
-    echo "Proceeding with creation..."
-    ;;
-  *)
-    echo "Exiting without creating..."
-    exit 0
-    ;;
+[yY][eE][sS] | [yY])
+  echo "Proceeding with creation..."
+  ;;
+*)
+  echo "Exiting without creating..."
+  exit 0
+  ;;
 esac
 
 ################################################################################

--- a/scripts/terraform-backend/terraform-backend.sh
+++ b/scripts/terraform-backend/terraform-backend.sh
@@ -106,7 +106,6 @@ fi
 ################################################################################
 
 echo "Creating resource group..."
-
 az group create \
   --name "$RESOURCE_GROUP_NAME" \
   --location "$LOCATION" \
@@ -117,7 +116,6 @@ az group create \
 ################################################################################
 
 echo "Creating storage account..."
-
 ALLOW_SHARED_KEY_ACCESS="false"
 ROLE="Storage Blob Data Owner"
 if [[ "$USE_AZUREAD_AUTH" != "true" ]]; then
@@ -179,7 +177,6 @@ az security atp storage update \
 ################################################################################
 
 echo "Creating storage container..."
-
 az storage container create \
   --name "$CONTAINER_NAME" \
   --account-name "$STORAGE_ACCOUNT_NAME" \
@@ -191,7 +188,6 @@ az storage container create \
 ################################################################################
 
 echo "Creating lifecycle policy..."
-
 MANAGEMENT_POLICY=$(echo "$CONFIG" | jq '{
   rules: [
     {
@@ -231,7 +227,6 @@ az storage account management-policy create \
 ################################################################################
 
 echo "Creating role assignment..."
-
 az role assignment create \
   --assignee "$OBJECT_ID" \
   --role "$ROLE" \
@@ -243,7 +238,6 @@ az role assignment create \
 ################################################################################
 
 echo "Creating resource lock..."
-
 az resource lock create \
   --name "$LOCK_NAME" \
   --lock-type ReadOnly \

--- a/scripts/terraform-backend/terraform-backend.sh
+++ b/scripts/terraform-backend/terraform-backend.sh
@@ -36,7 +36,9 @@ SUBSCRIPTION_NAME=$(az account show --query name --output tsv)
 readonly SUBSCRIPTION_NAME
 
 while true; do
-  read -r -p "Create Terraform backend in Azure subscription '$SUBSCRIPTION_NAME'? (y/N) " response
+  read -r -p "Create Terraform backend in \
+Azure subscription '$SUBSCRIPTION_NAME'? (y/N) " response
+
   case "$response" in
   [yY][eE][sS] | [yY])
     echo "Proceeding with creation..."

--- a/scripts/terraform-backend/terraform-backend.sh
+++ b/scripts/terraform-backend/terraform-backend.sh
@@ -196,7 +196,7 @@ az storage container create \
 ################################################################################
 
 echo "Creating lifecycle policy..."
-MANAGEMENT_POLICY=$(echo "$CONFIG" | jq '{
+POLICY=$(echo "$CONFIG" | jq '{
   rules: [
     {
       name: "Delete old tfstate versions",
@@ -222,12 +222,12 @@ MANAGEMENT_POLICY=$(echo "$CONFIG" | jq '{
     }
   ]
 }')
-readonly MANAGEMENT_POLICY
+readonly POLICY
 
 az storage account management-policy create \
   --account-name "$STORAGE_ACCOUNT_NAME" \
   --resource-group "$RESOURCE_GROUP_NAME" \
-  --policy "$MANAGEMENT_POLICY" \
+  --policy "$POLICY" \
   --output none
 
 ################################################################################

--- a/scripts/terraform-backend/terraform-backend.sh
+++ b/scripts/terraform-backend/terraform-backend.sh
@@ -35,24 +35,17 @@ hash jq 2>/dev/null || {
 SUBSCRIPTION_NAME=$(az account show --query name --output tsv)
 readonly SUBSCRIPTION_NAME
 
-while true; do
-  read -r -p "Create Terraform backend in \
+read -r -p "Create Terraform backend in \
 Azure subscription '$SUBSCRIPTION_NAME'? (y/N) " response
-
-  case "$response" in
+case "$response" in
   [yY][eE][sS] | [yY])
     echo "Proceeding with creation..."
-    break
     ;;
-  [nN][oO] | [nN])
+  *)
     echo "Exiting without creating..."
     exit 0
     ;;
-  *)
-    echo "Invalid input, please type 'y' or 'n'."
-    ;;
-  esac
-done
+esac
 
 ################################################################################
 # Read Terraform backend configuration

--- a/scripts/terraform-backend/terraform-backend.sh
+++ b/scripts/terraform-backend/terraform-backend.sh
@@ -14,17 +14,25 @@ readonly OBJECT_ID
 IP_ADDRESSES=${4:-""}
 readonly IP_ADDRESSES
 
+error() {
+  echo -e "\033[0;31mERROR: $*\033[0;37m" >&2
+}
+
+info() {
+  echo -e "\033[0;33mINFO: $*\033[0;37m"
+}
+
 ################################################################################
 # Verify installation of necessary software components
 ################################################################################
 
 hash az 2>/dev/null || {
-  echo -e "\nERROR: Azure CLI not found in PATH. Exiting... " >&2
+  error "Azure CLI not found in PATH."
   exit 1
 }
 
 hash jq 2>/dev/null || {
-  echo -e "\nERROR: jq not found in PATH. Exiting... " >&2
+  error "jq not found in PATH."
   exit 1
 }
 
@@ -95,8 +103,8 @@ fi
 readonly LOCK_ID
 
 if [[ -n "$LOCK_ID" ]]; then
-  echo -e "\n\033[0;33mStorage account is locked."
-  echo -e "Please remove the lock by running the following command:"
+  info "Storage account is locked."
+  info "Please remove the lock by running the following command:"
   echo -e "\n\033[0;36maz resource lock delete --ids $LOCK_ID\033[0m\n"
   exit 1
 fi

--- a/scripts/terraform-backend/terraform-backend.sh
+++ b/scripts/terraform-backend/terraform-backend.sh
@@ -119,7 +119,6 @@ az group create \
 # Create Azure Storage account
 ################################################################################
 
-echo "Creating storage account..."
 ALLOW_SHARED_KEY_ACCESS="false"
 ROLE="Storage Blob Data Owner"
 if [[ "$USE_AZUREAD_AUTH" != "true" ]]; then
@@ -135,6 +134,7 @@ if [[ -z "$IP_ADDRESSES" ]]; then
 fi
 readonly DEFAULT_ACTION
 
+echo "Creating storage account..."
 STORAGE_ACCOUNT_ID="$(az storage account create \
   --name "$STORAGE_ACCOUNT_NAME" \
   --resource-group "$RESOURCE_GROUP_NAME" \


### PR DESCRIPTION
Trying to prettify the Terraform backend script a bit to make it slightly more pleasant to work in and with.

- Use uppercase for environment variables and constants.
- Use lowercase for local variables.
- Set environment variables and constants to read-only as soon as possible.
- Only wrap variable references with `{}` if required.
- Add functions for printing error and info messages.
- Don't exceed 80 character line limit.

Similar to #571. That PR should be merged first so that this PR can get the benefits of the added `.editorconfig` file.