### PR TITLE
refactor(terraform): common logic for passing optional args

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -72,8 +72,6 @@ env:
   # Makes output more consistent and less confusing in workflows where users don't directly execute Terraform commands.
   TF_IN_AUTOMATION: true
 
-  TF_CLI_ARGS_init: -backend-config=${{ inputs.backend_config }}
-
   # Configure OIDC authentication to Azure using environment variables.
   # Required by the AzureRM backend and provider.
   ARM_USE_OIDC: true
@@ -121,7 +119,14 @@ jobs:
 
       - name: Terraform Init
         id: init
-        run: terraform init
+        env:
+          TFBACKEND_CONFIG: ${{ inputs.backend_config }}
+        run: |
+          optional_args=()
+          if [[ -n "$TFBACKEND_CONFIG" ]]; then
+            optional_args+=(-backend-config="$TFBACKEND_CONFIG")
+          fi
+          terraform init "${optional_args[@]}"
 
       - name: Terraform Validate
         id: validate
@@ -144,7 +149,6 @@ jobs:
           if [[ -n "$TFVARS_FILE" ]]; then
             optional_args+=(-var-file="$TFVARS_FILE")
           fi
-
           terraform plan -input=false -out="$TFPLAN_FILE" -detailed-exitcode "${optional_args[@]}"
 
           exitcode=$?


### PR DESCRIPTION
- Remove use of environment variable `TF_CLI_ARGS_init` to add optional arguments to `terraform init` command calls. This was useful back when we used to run `terraform init` twice in the workflow (since the environment variable would add the optional args to both command calls), however we no longer do that. Prefer the same logic for optional arguments used in step `Terraform Plan`, for consistency's sake. 
- Remove a newline in step `Terraform Plan`, effectively grouping related commands.