### PR TITLE
fix(terraform): formatting errors prevent job from running

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -121,6 +121,7 @@ jobs:
         # Required in order to check exitcode.
         # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
         shell: bash {0}
+        continue-on-error: true # Formatting errors should not prevent the job from running.
         run: |
           terraform fmt -check
           exitcode=$?

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -117,8 +117,14 @@ jobs:
 
       - name: Terraform Format
         id: fmt
-        run: terraform fmt -check
-        continue-on-error: true # Formatting errors should not prevent the job from running.
+        # Start Bash without fail-fast behavior.
+        # Required in order to check exitcode.
+        # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+        shell: bash {0}
+        run: |
+          terraform fmt -check
+          exitcode=$?
+          echo "exitcode=$exitcode" >> "$GITHUB_OUTPUT"
 
       - name: Terraform Init
         id: init
@@ -153,7 +159,6 @@ jobs:
             optional_args+=(-var-file="$TFVARS_FILE")
           fi
           terraform plan -input=false -out="$TFPLAN_FILE" -detailed-exitcode "${optional_args[@]}"
-
           exitcode=$?
           if [[ "$exitcode" == 1 ]]; then
             exit "$exitcode"
@@ -165,7 +170,7 @@ jobs:
       - name: Create job summary
         # Only run if Terraform Plan succeeded with non-empty diff (changes present).
         # Ref: https://developer.hashicorp.com/terraform/cli/commands/plan#detailed-exitcode
-        if: steps.plan.outputs.exitcode == 2
+        if: steps.fmt.outputs.exitcode != 0 || steps.plan.outputs.exitcode == 2
         shell: bash {0}
         env:
           TF_FMT_OUTCOME: ${{ steps.fmt.outcome }}

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -125,6 +125,7 @@ jobs:
           terraform fmt -check
           exitcode=$?
           echo "exitcode=$exitcode" >> "$GITHUB_OUTPUT"
+          exit "$exitcode"
 
       - name: Terraform Init
         id: init

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -115,6 +115,11 @@ jobs:
           # If the wrapper is enabled, the debug logs will be visible in the job summary.
           # The wrapper must be disabled to prevent this.
 
+      - name: Terraform Format
+        id: fmt
+        run: terraform fmt -check
+        continue-on-error: true # Formatting errors should not prevent the job from running.
+
       - name: Terraform Init
         id: init
         env:
@@ -163,6 +168,7 @@ jobs:
         if: steps.plan.outputs.exitcode == 2
         shell: bash {0}
         env:
+          TF_FMT_OUTCOME: ${{ steps.fmt.outcome }}
           TF_INIT_OUTCOME: ${{ steps.init.outcome }}
           TF_VALIDATE_OUTCOME: ${{ steps.validate.outcome }}
           TF_PLAN_OUTCOME: ${{ steps.plan.outcome }}
@@ -170,7 +176,8 @@ jobs:
         run: |
           tfplan=$(terraform show "$TFPLAN_FILE" -no-color)
 
-          echo "#### Terraform Initialization ⚙\`$TF_INIT_OUTCOME\`
+          echo "#### Terraform Format and Style 🖌\`$TF_FMT_OUTCOME\`
+          #### Terraform Initialization ⚙\`$TF_INIT_OUTCOME\`
           #### Terraform Validation 🤖\`$TF_VALIDATE_OUTCOME\`
           #### Terraform Plan 📖\`$TF_PLAN_OUTCOME\`
 


### PR DESCRIPTION
Instead of removing formatting check completely, simply configure the workflow to continue even when formatting check throws error. Consider it an alternative fix to #568.