### PR TITLE
feat(terraform): add option to run Apply on condition

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -41,6 +41,12 @@ on:
         type: string
         required: false
 
+      run_terraform_apply:
+        description: Run `terraform apply` for the saved plan file?
+        type: boolean
+        required: false
+        default: true
+
     secrets:
       AZURE_CLIENT_ID:
         description: The client ID of the Azure AD service principal to use for authenticating to Azure.
@@ -223,7 +229,7 @@ jobs:
   terraform-apply:
     name: Terraform Apply
     needs: terraform-plan
-    if: github.actor != 'dependabot[bot]' && needs.terraform-plan.outputs.upload-outcome == 'success'
+    if: github.actor != 'dependabot[bot]' && needs.terraform-plan.outputs.upload-outcome == 'success' && inputs.run_terraform_apply
     runs-on: ${{ inputs.runs_on }}
     environment: ${{ inputs.environment }}
     permissions:


### PR DESCRIPTION
- Add new input `run_terraform_apply`.
- If value is `true`, the `Terraform Apply` job will run after generating a plan.
- If value is `false`, the `Terraform Apply` job will **not** run after generating a plan.
- Default value is `true`, to keep the default behavior of the workflow the same as before.

This allows users to run `terraform apply` job based on a condition.

For example, run `terraform plan` on PR to branch `main`, then run `terraform plan` and `terraform apply` on push to branch `main`:

```yaml
on:
  pull_request:
    branches:
      - main
  push:
    branches:
      - main
jobs:
  example:
    uses: equinor/ops-actions/.github/workflows/terraform.yml@feat/terraform/add-option-to-run-apply-on-condition
    with:
      environment: dev
      run_terraform_apply: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
    secrets: inherit
```