### PR TITLE
fix(dotnet): no artifact uploaded

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -130,6 +130,8 @@ jobs:
       - name: Create tarball
         id: tar
         working-directory: ${{ steps.publish.outputs.publish_path }}
+        env:
+          ARTIFACT_NAME: ${{ inputs.artifact_name }}
         run: |
           tarball="$RUNNER_TEMP/$ARTIFACT_NAME.tar"
           tar -cvf "$tarball" .


### PR DESCRIPTION
Workflow fails due to no artifact is being generated. The workflow expects `$ARTIFACT_NAME` but its never speciefied, causing the path to end in a `.tar` file, which is classified as a hidden file.