### PR TITLE
fix(terraform): include plugins downloaded from cache in artifact

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -132,7 +132,7 @@ jobs:
       - name: Create Terraform plugin cache
         id: mkdir
         run: |
-          plugin_cache_dir="$RUNNER_TEMP/.terraform.d/plugin-cache"
+          plugin_cache_dir=".terraform.d/plugin-cache"
           mkdir --parents "$plugin_cache_dir"
           echo "plugin_cache_dir=$plugin_cache_dir" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
When enabling the plugin cache, Terraform will create symbolic links in the current working directory to the plugin cache directory. As a result, the plugin cache directory must be included in the artifact to be download by the `Terraform Apply` job.