### PR TITLE
fix(terraform): no plugins uploaded to cache

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -110,6 +110,11 @@ jobs:
         shell: bash
         working-directory: ${{ inputs.working_directory }}
 
+    env:
+      # Enable Terraform plugin cache.
+      # https://developer.hashicorp.com/terraform/cli/config/config-file#provider-plugin-cache
+      TF_PLUGIN_CACHE_DIR: ${{ github.workspace }}/${{ inputs.working_directory }}/.terraform.d/plugin-cache
+
     outputs:
       upload-outcome: ${{ steps.upload.outcome }}
       artifact-id: ${{ steps.upload.outputs.artifact-id }}
@@ -130,16 +135,12 @@ jobs:
           # The wrapper must be disabled to prevent this.
 
       - name: Create Terraform plugin cache
-        id: mkdir
-        run: |
-          plugin_cache_dir=".terraform.d/plugin-cache"
-          mkdir --parents "$plugin_cache_dir"
-          echo "plugin_cache_dir=$plugin_cache_dir" >> "$GITHUB_OUTPUT"
+        run: mkdir --parents "$TF_PLUGIN_CACHE_DIR"
 
       - name: Cache Terraform plugins
         uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
         with:
-          path: ${{ steps.mkdir.outputs.plugin_cache_dir }}
+          path: ${{ env.TF_PLUGIN_CACHE_DIR }}
           key: terraform-${{ hashFiles(format('{0}/.terraform.lock.hcl', inputs.working_directory)) }}
           # The dependency lock file tracks provider dependencies for the Terraform configuration in the working directory.
           # Calculate a hash for the dependency lock file and use this hash to identify the plugin cache for the Terraform configuration.
@@ -162,9 +163,6 @@ jobs:
         id: init
         env:
           TFBACKEND_CONFIG: ${{ inputs.backend_config }}
-          # Enable Terraform plugin cache.
-          # https://developer.hashicorp.com/terraform/cli/config/config-file#provider-plugin-cache
-          TF_PLUGIN_CACHE_DIR: ${{ steps.mkdir.outputs.plugin_cache_dir }}
         run: |
           optional_args=()
           if [[ -n "$TFBACKEND_CONFIG" ]]; then


### PR DESCRIPTION
`TF_PLUGIN_CACHE_DIR` should be an absolute path to ensure consistent behavior across actions and inline scripts. Currently the `actions/cache` action looks for plugins to cache at the incorrect path, resulting in an empty cache.