### PR TITLE
refactor(terraform): explicitly disable wrapper script

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -299,6 +299,7 @@ jobs:
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
         with:
           terraform_version: ${{ inputs.terraform_version }}
+          terraform_wrapper: false
 
       - name: Extract tarball
         run: |


### PR DESCRIPTION
No need to install Terraform wrapper script when its functionality is not used.

This is already done in the `terraform-plan` job.