### PR TITLE
fix(terraform): apply job should fail if unable to restore cache

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -294,6 +294,7 @@ jobs:
         with:
           path: ${{ needs.terraform-plan.outputs.plugin-cache-dir }}
           key: ${{ needs.terraform-plan.outputs.cache-primary-key }}
+          fail-on-cache-miss: true
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd


### PR DESCRIPTION
Plan job will either restore an existing cache or save cache. Thus, in the apply job, we can expect there to always be cache available. If not, something is wrong.