### PR TITLE
fix(terraform): apply job fails if lock file has not been commited

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -91,6 +91,7 @@ env:
   ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
   ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
 
+  TFLOCK_FILE: .terraform.lock.hcl
   TFPLAN_FILE: tfplan
   ARTIFACT_NAME: ${{ inputs.artifact_name || format('terraform-{0}', inputs.environment) }}
   ENCRYPTION_PASSWORD: ${{ secrets.ENCRYPTION_PASSWORD }}
@@ -115,6 +116,7 @@ jobs:
       artifact-id: ${{ steps.upload.outputs.artifact-id }}
       plugin-cache-dir: ${{ steps.mkdir.outputs.plugin-cache-dir }}
       cache-primary-key: ${{ steps.cache-restore.outputs.cache-primary-key }}
+      cache-save-outcome: ${{ steps.cache-save.outcome }}
 
     steps:
       - name: Checkout
@@ -131,19 +133,28 @@ jobs:
           # If the wrapper is enabled, the debug logs will be visible in the job summary.
           # The wrapper must be disabled to prevent this.
 
+      # Enable Terraform plugin cache.
+      # https://developer.hashicorp.com/terraform/cli/config/config-file#provider-plugin-cache
       - name: Create Terraform plugin cache
         id: mkdir
         run: |
-          plugin_cache_dir="$HOME/.terraform.d/plugin-cache"
-          mkdir --parents "$plugin_cache_dir"
+          plugin_cache_dir=""
+          if [[ -f "$TFLOCK_FILE" ]]; then
+            plugin_cache_dir="$HOME/.terraform.d/plugin-cache"
+            mkdir --parents "$plugin_cache_dir"
+            echo "TF_PLUGIN_CACHE_DIR=$plugin_cache_dir" >> "$GITHUB_ENV"
+          else
+            echo "Dependency lock file not found. Terraform plugin cache will not be enabled."
+          fi
           echo "plugin-cache-dir=$plugin_cache_dir" >> "$GITHUB_OUTPUT"
 
       - name: Restore cache
         id: cache-restore
+        if: steps.mkdir.outputs.plugin-cache.dir != ''
         uses: actions/cache/restore@6849a6489940f00c2f30c0fb92c6274307ccb58a
         with:
           path: ${{ steps.mkdir.outputs.plugin-cache-dir }}
-          key: ${{ runner.os }}-terraform-${{ hashFiles(format('{0}/.terraform.lock.hcl', inputs.working_directory)) }}
+          key: ${{ runner.os }}-terraform-${{ hashFiles(format('{0}/{1}', inputs.working_directory, env.TFLOCK_FILE)) }}
           # The dependency lock file tracks provider dependencies for the Terraform configuration in the working directory.
           # Calculate a hash for the dependency lock file and use this hash to identify the plugin cache for the Terraform configuration.
           # https://developer.hashicorp.com/terraform/language/files/dependency-lock
@@ -165,9 +176,6 @@ jobs:
         id: init
         env:
           TFBACKEND_CONFIG: ${{ inputs.backend_config }}
-          # Enable Terraform plugin cache.
-          # https://developer.hashicorp.com/terraform/cli/config/config-file#provider-plugin-cache
-          TF_PLUGIN_CACHE_DIR: ${{ steps.mkdir.outputs.plugin-cache-dir }}
         run: |
           optional_args=()
           if [[ -n "$TFBACKEND_CONFIG" ]]; then
@@ -257,7 +265,8 @@ jobs:
           retention-days: 35
 
       - name: Save cache
-        if: steps.cache-restore.outputs.cache-hit != 'true'
+        id: cache-save
+        if: steps.cache-restore.outcome == 'success' && steps.cache-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@6849a6489940f00c2f30c0fb92c6274307ccb58a
         with:
           path: ${{ steps.mkdir.outputs.plugin-cache-dir }}
@@ -290,6 +299,7 @@ jobs:
           path: ${{ inputs.working_directory }}
 
       - name: Restore cache
+        if: needs.terraform-plan.outputs.cache-save-outcome == 'success'
         uses: actions/cache/restore@6849a6489940f00c2f30c0fb92c6274307ccb58a
         with:
           path: ${{ needs.terraform-plan.outputs.plugin-cache-dir }}

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -150,7 +150,7 @@ jobs:
 
       - name: Restore cache
         id: cache-restore
-        if: steps.mkdir.outputs.plugin-cache.dir != ''
+        if: steps.mkdir.outputs.plugin-cache-dir != ''
         uses: actions/cache/restore@6849a6489940f00c2f30c0fb92c6274307ccb58a
         with:
           path: ${{ steps.mkdir.outputs.plugin-cache-dir }}


### PR DESCRIPTION
Cache functionality currently breaks the workflow if the dependency lock file (`.terraform.lock.hcl`) has not been commited.

While it's _recommended_ to commit the lock file, it's not _required_. It should be okay to skip caching plugins if lock file has not been commited.

## Implementation

Check if lock file exists:

- If yes, enable plugin cache.
- If no, don't enable plugin cache and skip all cache related steps.

## Testing

- [x] Tested and verified to work when lock file has been commited.
- [x] Tested and verified to work when lock file has not been commited.

(see results in comments)