### PR TITLE
refactor: declare job outputs and end of job

### DIFF
--- a/.github/workflows/docker-acr.yml
+++ b/.github/workflows/docker-acr.yml
@@ -72,10 +72,6 @@ jobs:
       IMAGE: ${{ inputs.registry_name }}.azurecr.io/${{ inputs.repository }}:${{ inputs.tag }}
       IMAGE_LATEST: ${{ inputs.registry_name }}.azurecr.io/${{ inputs.repository }}:latest
 
-    outputs:
-      image: ${{ env.IMAGE }}
-      image_latest: ${{ env.IMAGE_LATEST }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -103,3 +99,7 @@ jobs:
           context: ${{ inputs.working_directory }}
           tags: ${{ env.IMAGE }},${{ env.IMAGE_LATEST }}
           push: true
+
+    outputs:
+      image: ${{ env.IMAGE }}
+      image_latest: ${{ env.IMAGE_LATEST }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -68,10 +68,6 @@ jobs:
       IMAGE: ${{ inputs.registry }}/${{ inputs.repository }}:${{ inputs.tag }}
       IMAGE_LATEST: ${{ inputs.registry }}/${{ inputs.repository }}:latest
 
-    outputs:
-      image: ${{ env.IMAGE }}
-      image_latest: ${{ env.IMAGE_LATEST }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -94,3 +90,7 @@ jobs:
           context: ${{ inputs.working_directory }}
           tags: ${{ env.IMAGE }},${{ env.IMAGE_LATEST }}
           push: true
+
+    outputs:
+      image: ${{ env.IMAGE }}
+      image_latest: ${{ env.IMAGE_LATEST }}

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -111,13 +111,6 @@ jobs:
         shell: bash
         working-directory: ${{ inputs.working_directory }}
 
-    outputs:
-      upload-outcome: ${{ steps.upload.outcome }}
-      artifact-id: ${{ steps.upload.outputs.artifact-id }}
-      plugin-cache-dir: ${{ steps.mkdir.outputs.plugin-cache-dir }}
-      cache-primary-key: ${{ steps.cache-restore.outputs.cache-primary-key }}
-      cache-save-outcome: ${{ steps.cache-save.outcome }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -271,6 +264,13 @@ jobs:
         with:
           path: ${{ steps.mkdir.outputs.plugin-cache-dir }}
           key: ${{ steps.cache-restore.outputs.cache-primary-key }}
+
+    outputs:
+      upload-outcome: ${{ steps.upload.outcome }}
+      artifact-id: ${{ steps.upload.outputs.artifact-id }}
+      plugin-cache-dir: ${{ steps.mkdir.outputs.plugin-cache-dir }}
+      cache-primary-key: ${{ steps.cache-restore.outputs.cache-primary-key }}
+      cache-save-outcome: ${{ steps.cache-save.outcome }}
 
   terraform-apply:
     name: Terraform Apply


### PR DESCRIPTION
Job outputs often reference the steps in the job, so it makes more sense to place the outputs after the steps they reference.