### PR TITLE
feat(terraform): validate configuration if triggered by Dependabot

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -276,7 +276,7 @@ jobs:
   terraform-apply:
     name: Terraform Apply
     needs: terraform-plan
-    if: github.actor != 'dependabot[bot]' && needs.terraform-plan.outputs.upload-outcome == 'success' && inputs.run_terraform_apply
+    if: needs.terraform-plan.outputs.upload-outcome == 'success' && inputs.run_terraform_apply
     runs-on: ${{ inputs.runs_on }}
     environment: ${{ inputs.environment }}
     permissions:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -100,7 +100,6 @@ jobs:
   terraform-plan:
     name: Terraform Plan
     runs-on: ${{ inputs.runs_on }}
-    if: github.actor != 'dependabot[bot]'
     environment: ${{ inputs.environment }}
     permissions:
       contents: read # Required to checkout the repository
@@ -170,7 +169,9 @@ jobs:
           TFBACKEND_CONFIG: ${{ inputs.backend_config }}
         run: |
           optional_args=()
-          if [[ -n "$TFBACKEND_CONFIG" ]]; then
+          if [[ "$GITHUB_ACTOR" == "dependabot[bot]" ]]; then
+            optional_args+=(-backend=false)
+          elif [[ -n "$TFBACKEND_CONFIG" ]]; then
             optional_args+=(-backend-config="$TFBACKEND_CONFIG")
           fi
           terraform init "${optional_args[@]}"
@@ -185,6 +186,7 @@ jobs:
       # Ref: https://developer.hashicorp.com/terraform/tutorials/automation/automate-terraform#plan-and-apply-on-different-machines
       - name: Terraform Plan
         id: plan
+        if: github.actor != 'dependabot[bot]'
         # Start Bash without fail-fast behavior.
         # Required in order to check exitcode.
         # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference


### PR DESCRIPTION
Currently, if the Terraform workflow is triggered by Dependabot, both the `Terraform Plan` and `Terraform Apply` jobs are skipped, meaning the workflow does nothing 🤷 With the changes in this PR, the workflow should run until at least the `Terraform Validate` step to catch obvious errors.

If triggered by Dependabot, it's important that the Terraform backend is _not_ initialized when running `terraform init`, since that requires authentication to Azure, which Dependabot can't do.