### PR TITLE
fix(dotnet): skip Node.js setup if no version specified

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,10 +16,9 @@ on:
         required: true
 
       node_version:
-        description: The version of Node.js to install.
+        description: A specific version of Node.js to install. Use to override pre-installed version on GitHub-hosted runners.
         type: string
         required: false
-        default: latest
 
       npm_version:
         description: A specific version of npm to install. Use to override pre-installed version on GitHub-hosted runners.
@@ -92,6 +91,7 @@ jobs:
           dotnet-version: ${{ inputs.dotnet_version }}
 
       - name: Setup Node.js
+        if: inputs.node_version != ''
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
         with:
           node-version: ${{ inputs.node_version }}


### PR DESCRIPTION
npm allows you to install packages for ASP.NET Core applications.

Some ASP.NET Core applications might require a specific version of npm and Node.js to be installed. If yes, this workflow should install the specified versions (already implemented). Else, this workflow should skip the setup of npm (already implemented) and Node.js (implemented in this commit).