### PR TITLE
fix(terraform): cache not restored in Apply job

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -269,6 +269,7 @@ jobs:
       artifact-id: ${{ steps.upload.outputs.artifact-id }}
       plugin-cache-dir: ${{ steps.mkdir.outputs.plugin-cache-dir }}
       cache-primary-key: ${{ steps.cache-restore.outputs.cache-primary-key }}
+      cache-restore-hit: ${{ steps.cache-restore.outputs.cache-hit }}
       cache-save-outcome: ${{ steps.cache-save.outcome }}
 
   terraform-apply:
@@ -298,7 +299,7 @@ jobs:
           path: ${{ inputs.working_directory }}
 
       - name: Restore cache
-        if: needs.terraform-plan.outputs.cache-save-outcome == 'success'
+        if: needs.terraform-plan.outputs.cache-restore-hit == 'true' || needs.terraform-plan.outputs.cache-save-outcome == 'success'
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
         with:
           path: ${{ needs.terraform-plan.outputs.plugin-cache-dir }}


### PR DESCRIPTION
The `Terraform Apply` job does not restore cache if the `Terraform Plan` job does not save cache. This causes an error in scenarios where cache already exists, and it'll only be restored in the `Terraform Plan` job but not the `Terraform Apply` job.