### PR TITLE
fix(terraform): no log output when plugin cache enabled

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -135,6 +135,7 @@ jobs:
             plugin_cache_dir="$HOME/.terraform.d/plugin-cache"
             mkdir --parents "$plugin_cache_dir"
             echo "TF_PLUGIN_CACHE_DIR=$plugin_cache_dir" >> "$GITHUB_ENV"
+            echo "Terraform plugin cache enabled."
           else
             echo "Dependency lock file not found. Terraform plugin cache will not be enabled."
           fi


### PR DESCRIPTION
Currently, the `Enable Terraform plugin cache` step does not output anything to the log when the plugin cache is enabled.

Add an `echo` command to output to log that the plugin cache was enabled.