### PR TITLE
revert(terraform): validate configuration if triggered by Dependabot

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -100,6 +100,7 @@ jobs:
   terraform-plan:
     name: Terraform Plan
     runs-on: ${{ inputs.runs_on }}
+    if: github.actor != 'dependabot[bot]'
     environment: ${{ inputs.environment }}
     permissions:
       contents: read # Required to checkout the repository
@@ -170,9 +171,7 @@ jobs:
           TFBACKEND_CONFIG: ${{ inputs.backend_config }}
         run: |
           optional_args=()
-          if [[ "$GITHUB_ACTOR" == "dependabot[bot]" ]]; then
-            optional_args+=(-backend=false)
-          elif [[ -n "$TFBACKEND_CONFIG" ]]; then
+          if [[ -n "$TFBACKEND_CONFIG" ]]; then
             optional_args+=(-backend-config="$TFBACKEND_CONFIG")
           fi
           terraform init "${optional_args[@]}"
@@ -187,7 +186,6 @@ jobs:
       # Ref: https://developer.hashicorp.com/terraform/tutorials/automation/automate-terraform#plan-and-apply-on-different-machines
       - name: Terraform Plan
         id: plan
-        if: github.actor != 'dependabot[bot]'
         # Start Bash without fail-fast behavior.
         # Required in order to check exitcode.
         # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
@@ -278,7 +276,7 @@ jobs:
   terraform-apply:
     name: Terraform Apply
     needs: terraform-plan
-    if: needs.terraform-plan.outputs.upload-outcome == 'success' && inputs.run_terraform_apply
+    if: github.actor != 'dependabot[bot]' && needs.terraform-plan.outputs.upload-outcome == 'success' && inputs.run_terraform_apply
     runs-on: ${{ inputs.runs_on }}
     environment: ${{ inputs.environment }}
     permissions:


### PR DESCRIPTION
The Terraform workflow currently throws an error if triggered by Dependabot and Dependabot secrets `AZURE_CLIENT_ID`, `AZURE_SUBSCRIPTION_ID` and/or `AZURE_TENANT_ID` are not configured, as these secrets are required by the Terraform workflow.

There are two possible solutions to this issue:

1. Set these secrets as not required in the Terraform workflow. The downside of this solution is that it can cause confusion regarding the usage of the Terraform workflow, as these secrets are still required for normal use, they're just not marked as required to prevent this error when triggered by Dependabot.

2. Add these Dependabot secrets to the relevant repository and set the values to empty strings. This adds an, in my opinion, unnecessary and confusing prerequisite for the Terraform workflow.

3. Revert the commit that broke the Terraform workflow.

Going for solution 3 keeps the Terraform workflow as simple as possible, so that is the solution that I've gone for.

This reverts commit 9d552d9811de33b0ce670c4bddbd39fc083ddc0e.