### PR TITLE
refactor(dotnet): consistent envvar names

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -76,10 +76,10 @@ jobs:
       contents: read # Required to checkout the repository
 
     env:
-      PROJECT: ${{ inputs.project }}
-      CONFIGURATION: Release
-      RUNTIME: ${{ inputs.runtime }}
-      SELF_CONTAINED: ${{ inputs.self_contained }}
+      DOTNET_PROJECT: ${{ inputs.project }}
+      DOTNET_CONFIGURATION: Release
+      DOTNET_RUNTIME: ${{ inputs.runtime }}
+      DOTNET_SELF_CONTAINED: ${{ inputs.self_contained }}
 
     steps:
       - name: Checkout
@@ -104,22 +104,22 @@ jobs:
 
       # Restore dependencies for the application and runtime.
       - name: .NET Restore
-        run: dotnet restore "$PROJECT" --runtime "$RUNTIME"
+        run: dotnet restore "$DOTNET_PROJECT" --runtime "$DOTNET_RUNTIME"
 
       # Build the application for release/deployment.
       - name: .NET Build
-        run: dotnet build "$PROJECT" --configuration "$CONFIGURATION" --runtime "$RUNTIME" --self-contained "$SELF_CONTAINED" --no-restore
+        run: dotnet build "$DOTNET_PROJECT" --configuration "$DOTNET_CONFIGURATION" --runtime "$DOTNET_RUNTIME" --self-contained "$DOTNET_SELF_CONTAINED" --no-restore
 
       # Execute unit tests.
       - name: .NET Test
         if: inputs.test_project != ''
         env:
-          PROJECT: ${{ inputs.test_project }}
-          COLLECT: ${{ inputs.test_collect }}
+          DOTNET_TEST_PROJECT: ${{ inputs.test_project }}
+          DOTNET_TEST_COLLECT: ${{ inputs.test_collect }}
         run: |
-          while read -r proj; do
-            dotnet test "$proj" --configuration "$CONFIGURATION" --collect "$COLLECT"
-          done <<< "$PROJECT"
+          while read -r project; do
+            dotnet test "$project" --configuration "$DOTNET_CONFIGURATION" --collect "$DOTNET_TEST_COLLECT"
+          done <<< "$DOTNET_TEST_PROJECT"
 
       # Publish the application and its dependencies to a folder for deployment.
       - name: .NET Publish
@@ -127,7 +127,7 @@ jobs:
         env:
           OUTPUT: ${{ runner.temp }}/${{ inputs.artifact_name }}
         run: |
-          dotnet publish "$PROJECT" --configuration "$CONFIGURATION" --runtime "$RUNTIME" --self-contained "$SELF_CONTAINED" --output "$OUTPUT" --no-build
+          dotnet publish "$DOTNET_PROJECT" --configuration "$DOTNET_CONFIGURATION" --runtime "$DOTNET_RUNTIME" --self-contained "$DOTNET_SELF_CONTAINED" --output "$OUTPUT" --no-build
           echo "publish_path=$OUTPUT" >> "$GITHUB_OUTPUT"
 
       - name: Create tarball

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -125,10 +125,10 @@ jobs:
       - name: .NET Publish
         id: publish
         env:
-          OUTPUT: ${{ runner.temp }}/${{ inputs.artifact_name }}
+          DOTNET_PUBLISH_OUTPUT: ${{ runner.temp }}/${{ inputs.artifact_name }}
         run: |
-          dotnet publish "$DOTNET_PROJECT" --configuration "$DOTNET_CONFIGURATION" --runtime "$DOTNET_RUNTIME" --self-contained "$DOTNET_SELF_CONTAINED" --output "$OUTPUT" --no-build
-          echo "publish_path=$OUTPUT" >> "$GITHUB_OUTPUT"
+          dotnet publish "$DOTNET_PROJECT" --configuration "$DOTNET_CONFIGURATION" --runtime "$DOTNET_RUNTIME" --self-contained "$DOTNET_SELF_CONTAINED" --output "$DOTNET_PUBLISH_OUTPUT" --no-build
+          echo "publish_path=$DOTNET_PUBLISH_OUTPUT" >> "$GITHUB_OUTPUT"
 
       - name: Create tarball
         id: tar


### PR DESCRIPTION
.NET related environment variables should be prefixed `DOTNET_`.