### PR TITLE
refactor: update descriptions for Azure secrets

### DIFF
--- a/.github/workflows/azure-function.yml
+++ b/.github/workflows/azure-function.yml
@@ -41,15 +41,15 @@ on:
 
     secrets:
       AZURE_CLIENT_ID:
-        description: The client ID of the Azure AD service principal to use for authenticating to Azure.
+        description: The client ID of the service principal to use for authenticating to Azure.
         required: true
 
       AZURE_SUBSCRIPTION_ID:
-        description: The ID of the Azure subscription to deploy the package to.
+        description: The ID of the Azure subscription to authenticate to.
         required: true
 
       AZURE_TENANT_ID:
-        description: The ID of the Azure tenant to deploy the package to.
+        description: The ID of the Microsoft Entra tenant to authenticate to.
         required: true
 
 permissions: {}

--- a/.github/workflows/azure-webapp.yml
+++ b/.github/workflows/azure-webapp.yml
@@ -47,15 +47,15 @@ on:
 
     secrets:
       AZURE_CLIENT_ID:
-        description: The client ID of the Azure AD service principal to use for authenticating to Azure.
+        description: The client ID of the service principal to use for authenticating to Azure.
         required: true
 
       AZURE_SUBSCRIPTION_ID:
-        description: The ID of the Azure subscription containing the Azure Web App.
+        description: The ID of the Azure subscription to authenticate to.
         required: true
 
       AZURE_TENANT_ID:
-        description: The ID of the Azure tenant containing the Azure Web App.
+        description: The ID of the Microsoft Entra tenant to authenticate to.
         required: true
 
 permissions: {}

--- a/.github/workflows/docker-acr.yml
+++ b/.github/workflows/docker-acr.yml
@@ -40,15 +40,15 @@ on:
 
     secrets:
       AZURE_CLIENT_ID:
-        description: The client ID of the Azure AD service principal to use for authenticating to Azure.
+        description: The client ID of the service principal to use for authenticating to Azure.
         required: true
 
       AZURE_SUBSCRIPTION_ID:
-        description: The ID of the Azure subscription containing the Container Registry.
+        description: The ID of the Azure subscription to authenticate to.
         required: true
 
       AZURE_TENANT_ID:
-        description: The ID of the Azure tenant containing the Container Registry.
+        description: The ID of the Microsoft Entra tenant to authenticate to.
         required: true
 
     outputs:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -57,15 +57,15 @@ on:
 
     secrets:
       AZURE_CLIENT_ID:
-        description: The client ID of the Azure AD service principal to use for authenticating to Azure.
+        description: The client ID of the service principal to use for authenticating to Azure.
         required: true
 
       AZURE_SUBSCRIPTION_ID:
-        description: The ID of the Azure subscription to create the resources in.
+        description: The ID of the Azure subscription to authenticate to.
         required: true
 
       AZURE_TENANT_ID:
-        description: The ID of the Azure tenant to create the resources in.
+        description: The ID of the Microsoft Entra tenant to authenticate to.
         required: true
 
       ENCRYPTION_PASSWORD:


### PR DESCRIPTION
* Change `Azure AD` to `Microsoft Entra`.
* Clarify that these secrets are for configuring authentication to Azure.

Release-As: 9.13.3