### PR TITLE
refactor(mkdocs)!: rename input `requirements` to `pip_requirements_file`

### DIFF
--- a/.github/workflows/mkdocs-gh-pages.yml
+++ b/.github/workflows/mkdocs-gh-pages.yml
@@ -22,16 +22,15 @@ on:
         default: latest
 
       mkdocs_version:
-        description: The version of MkDocs to install using PIP.
+        description: The version of MkDocs to install using pip.
         type: string
         required: false
         default: ">=1.0.0"
 
-      requirements:
-        description: The path of a file containing the Python packages to install using PIP, usually "requirements.txt".
+      pip_requirements_file:
+        description: The path of a pip requirements file (usually `requirements.txt`) that specifies Python dependencies to install.
         type: string
         required: false
-        default: ""
 
 permissions: {}
 
@@ -58,11 +57,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install "mkdocs$MKDOCS_VERSION"
 
-      - name: Install dependencies
-        if: inputs.requirements != ''
+      - name: Install Python dependencies
+        if: inputs.pip_requirements_file != ''
         env:
-          REQUIREMENTS: ${{ inputs.requirements }}
-        run: pip install -r "$REQUIREMENTS"
+          PIP_REQUIREMENTS_FILE: ${{ inputs.pip_requirements_file }}
+        run: pip install --requirement "$PIP_REQUIREMENTS_FILE"
 
       - name: Deploy MkDocs
         run: mkdocs gh-deploy --force

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -21,7 +21,7 @@ on:
         required: false
         default: ">=1.0.0"
 
-      pip_requirements_file:
+      pip_requirement:
         description: The path of a pip requirements file (usually `requirements.txt`) that specifies Python dependencies to install.
         type: string
         required: false
@@ -67,10 +67,10 @@ jobs:
           pip install "mkdocs$MKDOCS_VERSION"
 
       - name: Install Python dependencies
-        if: inputs.pip_requirements_file != ''
+        if: inputs.pip_requirement != ''
         env:
-          PIP_REQUIREMENTS_FILE: ${{ inputs.pip_requirements_file }}
-        run: pip install --requirement "$PIP_REQUIREMENTS_FILE"
+          PIP_REQUIREMENT: ${{ inputs.pip_requirement }}
+        run: pip install
 
       - name: MkDocs Build
         run: mkdocs build --site-dir "$SITE_DIR"

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -16,16 +16,15 @@ on:
         default: latest
 
       mkdocs_version:
-        description: The version of MkDocs to install using PIP.
+        description: The version of MkDocs to install using pip.
         type: string
         required: false
         default: ">=1.0.0"
 
-      requirements:
-        description: The path of a file containing the Python packages to install using PIP, usually "requirements.txt".
+      pip_requirements_file:
+        description: The path of a pip requirements file (usually `requirements.txt`) that specifies Python dependencies to install.
         type: string
         required: false
-        default: ""
 
       artifact_name:
         description: The name of the artifact to upload.
@@ -67,11 +66,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install "mkdocs$MKDOCS_VERSION"
 
-      - name: Install dependencies
-        if: inputs.requirements != ''
+      - name: Install Python dependencies
+        if: inputs.pip_requirements_file != ''
         env:
-          REQUIREMENTS: ${{ inputs.requirements }}
-        run: pip install -r "$REQUIREMENTS"
+          PIP_REQUIREMENTS_FILE: ${{ inputs.pip_requirements_file }}
+        run: pip install --requirement "$PIP_REQUIREMENTS_FILE"
 
       - name: MkDocs Build
         run: mkdocs build --site-dir "$SITE_DIR"

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -21,7 +21,7 @@ on:
         required: false
         default: ">=1.0.0"
 
-      pip_requirement:
+      pip_requirements_file:
         description: The path of a pip requirements file (usually `requirements.txt`) that specifies Python dependencies to install.
         type: string
         required: false
@@ -67,10 +67,10 @@ jobs:
           pip install "mkdocs$MKDOCS_VERSION"
 
       - name: Install Python dependencies
-        if: inputs.pip_requirement != ''
+        if: inputs.pip_requirements_file != ''
         env:
-          PIP_REQUIREMENT: ${{ inputs.pip_requirement }}
-        run: pip install
+          PIP_REQUIREMENTS_FILE: ${{ inputs.pip_requirements_file }}
+        run: pip install -r "$PIP_REQUIREMENTS_FILE"
 
       - name: MkDocs Build
         run: mkdocs build --site-dir "$SITE_DIR"


### PR DESCRIPTION
According to [naming convention](https://github.com/equinor/ops-actions/blob/9b8228ae81c68626f4f7312811d82cbd0c969e09/docs/best-practices.md#naming-conventions), the input should be named `pip_install_requirement`, however the term "pip requirements file" is used in the [official pip documentation](https://pip.pypa.io/en/stable/reference/requirements-file-format/), which I think "rolls of the tongue" very easily.