### PR TITLE
feat(dotnet)!: remove support for multi-line value for input `test_project`

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -44,7 +44,7 @@ on:
         default: false
 
       test_project:
-        description: Specify the path of a test project or solution file, or the path of a directory containing a test project or solution file. Pass a newline-separated string to specify multiple test projects.
+        description: Specify the path of a test project or solution file, or the path of a directory containing a test project or solution file.
         type: string
         required: false
         default: ""
@@ -116,10 +116,7 @@ jobs:
         env:
           DOTNET_TEST_PROJECT: ${{ inputs.test_project }}
           DOTNET_TEST_COLLECT: ${{ inputs.test_collect }}
-        run: |
-          while read -r project; do
-            dotnet test "$project" --configuration "$DOTNET_CONFIGURATION" --collect "$DOTNET_TEST_COLLECT"
-          done <<< "$DOTNET_TEST_PROJECT"
+        run: dotnet test "$DOTNET_TEST_PROJECT" --configuration "$DOTNET_CONFIGURATION" --collect "$DOTNET_TEST_COLLECT"
 
       # Publish the application and its dependencies to a folder for deployment.
       - name: .NET Publish

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -47,7 +47,6 @@ on:
         description: Specify the path of a test project or solution file, or the path of a directory containing a test project or solution file.
         type: string
         required: false
-        default: ""
 
       test_collect:
         description: Enables data collector for the test run.


### PR DESCRIPTION
Specify the path of a solution file that references multiple test projects instead.