### PR TITLE
refactor(python): rename input `pip_install_target` to `pip_target`

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -26,7 +26,7 @@ on:
         type: string
         required: false
 
-      pip_install_target:
+      pip_target:
         description: The target directory that PIP should install packages into (relative to working directory).
         type: string
         required: false
@@ -75,10 +75,10 @@ jobs:
 
       - name: Install dependencies
         env:
-          TARGET: ${{ inputs.pip_install_target }}
+          PIP_TARGET: ${{ inputs.pip_target }}
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt --target "$TARGET"
+          pip install -r requirements.txt
 
       - name: Create tarball
         id: tar


### PR DESCRIPTION
Replace `pip install` command option `--target` with environment variable `PIP_TARGET` ([ref.](https://pip.pypa.io/en/stable/cli/pip_install/)). Rename corresponding input accordingly.

Input name follows [naming convention](https://github.com/equinor/ops-actions/blob/9b8228ae81c68626f4f7312811d82cbd0c969e09/docs/best-practices.md#naming-conventions).