### PR TITLE
refactor(dotnet)!: rename input `test_collect` to `data_collector`

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -49,7 +49,7 @@ on:
         required: false
         default: ""
 
-      test_collect:
+      data_collector:
         description: The name of a data collector to enable for the test run, for example `Code Coverage`.
         type: string
         required: false
@@ -114,7 +114,7 @@ jobs:
         if: inputs.test_project != ''
         env:
           DOTNET_TEST_PROJECT: ${{ inputs.test_project }}
-          DOTNET_TEST_COLLECT: ${{ inputs.test_collect }}
+          DOTNET_TEST_COLLECT: ${{ inputs.data_collector }}
         run: |
           while read -r project; do
             dotnet test "$project" --configuration "$DOTNET_CONFIGURATION" --collect "$DOTNET_TEST_COLLECT"


### PR DESCRIPTION
According to [naming convention](https://github.com/equinor/ops-actions/blob/9b8228ae81c68626f4f7312811d82cbd0c969e09/docs/best-practices.md#naming-conventions), the input should be named `test_collect`, however the term "data collector" is used in the [official `dotnet test` documentation](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-test), which I think "rolls of the tongue" very easily.