### PR TITLE
feat: disable Azure CLI output by default

### DIFF
--- a/.github/workflows/azure-function.yml
+++ b/.github/workflows/azure-function.yml
@@ -54,6 +54,11 @@ on:
 
 permissions: {}
 
+env:
+  # Disable output from Azure CLI commands by default, as some commands may output secrets.
+  # Output can be explicitly enabled for commands that require it by using the "--output" argument.
+  AZURE_CORE_OUTPUT: none
+
 jobs:
   azure-function:
     name: Azure Function

--- a/.github/workflows/azure-webapp.yml
+++ b/.github/workflows/azure-webapp.yml
@@ -60,6 +60,11 @@ on:
 
 permissions: {}
 
+env:
+  # Disable output from Azure CLI commands by default, as some commands may output secrets.
+  # Output can be explicitly enabled for commands that require it by using the "--output" argument.
+  AZURE_CORE_OUTPUT: none
+
 jobs:
   azure-webapp:
     name: Azure Web App

--- a/.github/workflows/docker-acr.yml
+++ b/.github/workflows/docker-acr.yml
@@ -58,6 +58,11 @@ on:
 
 permissions: {}
 
+env:
+  # Disable output from Azure CLI commands by default, as some commands may output secrets.
+  # Output can be explicitly enabled for commands that require it by using the "--output" argument.
+  AZURE_CORE_OUTPUT: none
+
 jobs:
   docker:
     name: Docker


### PR DESCRIPTION
Some commands may output secrets. Output can be explicitly enabled for commands that require it by using the `--output` argument.