### PR TITLE
docs: disable Azure CLI output by default

### DIFF
--- a/.github/workflows/azure-function.yml
+++ b/.github/workflows/azure-function.yml
@@ -55,8 +55,6 @@ on:
 permissions: {}
 
 env:
-  # Disable output from Azure CLI commands by default, as some commands may output secrets.
-  # Output can be explicitly enabled for commands that require it by using the "--output" argument.
   AZURE_CORE_OUTPUT: none
 
 jobs:

--- a/.github/workflows/azure-webapp.yml
+++ b/.github/workflows/azure-webapp.yml
@@ -61,8 +61,6 @@ on:
 permissions: {}
 
 env:
-  # Disable output from Azure CLI commands by default, as some commands may output secrets.
-  # Output can be explicitly enabled for commands that require it by using the "--output" argument.
   AZURE_CORE_OUTPUT: none
 
 jobs:

--- a/.github/workflows/docker-acr.yml
+++ b/.github/workflows/docker-acr.yml
@@ -59,8 +59,6 @@ on:
 permissions: {}
 
 env:
-  # Disable output from Azure CLI commands by default, as some commands may output secrets.
-  # Output can be explicitly enabled for commands that require it by using the "--output" argument.
   AZURE_CORE_OUTPUT: none
 
 jobs:

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -86,7 +86,7 @@ Written as an extension of [Security hardening for GitHub Actions](https://docs.
     AZURE_CORE_OUTPUT: none
   ```
 
-  Some Azure CLI commands may output secrets. Output can be explicitly enabled for commands that require it by using the [`--output` global parameter](https://learn.microsoft.com/en-us/cli/azure/azure-cli-global-parameters?tabs=tabid-1#--output-global-parameter).
+  This is to prevent Azure CLI commands from outputting secrets. Output can be explicitly enabled for commands that require it by using the [`--output` global parameter](https://learn.microsoft.com/en-us/cli/azure/azure-cli-global-parameters?tabs=tabid-1#--output-global-parameter).
 
 ## Naming conventions
 

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -79,6 +79,15 @@ Written as an extension of [Security hardening for GitHub Actions](https://docs.
 
   This ensures that all jobs are executed on a runner that includes the required software by default.
 
+- Workflows that run [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/) commands should declare the following top level environment variable to disable output from Azure CLI commands by default:
+
+  ```yaml
+  env:
+    AZURE_CORE_OUTPUT: none
+  ```
+
+  Some Azure CLI commands may output secrets. Output can be explicitly enabled for commands that require it by using the [`--output` global parameter](https://learn.microsoft.com/en-us/cli/azure/azure-cli-global-parameters?tabs=tabid-1#--output-global-parameter).
+
 ## Naming conventions
 
 - Use [kebab-case](https://en.wiktionary.org/wiki/kebab_case) for workflow filenames, job identifiers and step identifiers.


### PR DESCRIPTION
Remove duplicate comments in workflows, and add new item to best practices instead.