### PR TITLE
feat(databricks-repos): set default repo path

### DIFF
--- a/.github/workflows/databricks-repos.yml
+++ b/.github/workflows/databricks-repos.yml
@@ -31,7 +31,7 @@ on:
 
       repo_path:
         description: The path of the Git folder (repo) object in the Databricks workspace. Defaults to `/Repos/<GITHUB_REPOSITORY>`.
-        required: true
+        required: false
         type: string
         default: /Repos/${{ github.repository }}
 

--- a/.github/workflows/databricks-repos.yml
+++ b/.github/workflows/databricks-repos.yml
@@ -30,9 +30,10 @@ on:
         type: string
 
       repo_path:
-        description: The path of the Git folder (repo) object in the Databricks workspace.
+        description: The path of the Git folder (repo) object in the Databricks workspace. Defaults to `/Repos/<GITHUB_REPOSITORY>`.
         required: true
         type: string
+        default: /Repos/${{ github.repository }}
 
       branch:
         description: The branch that the local version of the repo is checked out to. Defaults to `main`.


### PR DESCRIPTION
Simplify the use of the `databricks-repos.yml` workflow by setting a default value for input `repo_path` that corresponds to the GitHub repository that is being pulled into Databricks.