### PR TITLE
feat(super-linter): prefer Ruff over Flake8 and isort

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -51,7 +51,7 @@ jobs:
           # For example, if using the `nullable` argument in a Terraform variable block, Terrascan throws an error. This argument was added in Terraform v1.1 (https://developer.hashicorp.com/terraform/language/values/variables#disallowing-null-input-values).
           VALIDATE_TERRAFORM_TERRASCAN: false
           # For Python, prefer the Ruff linter over Flake8 and isort.
-          # The Ruff linter is faster than, has feature parity with, and serves as a drop-in replacement, for both Flake8 and isort.
+          # The Ruff linter is faster than, has feature parity with, and serves as a drop-in replacement for both Flake8 and isort.
           # The Ruff formatter also has feature parity with Black, however Super-linter does not yet support the Ruff formatter.
           # Ref: https://docs.astral.sh/ruff/
           VALIDATE_PYTHON_FLAKE8: false

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -50,3 +50,9 @@ jobs:
           # Terrascan is not actively maintained as of 11.11.2024, which results in outdated errors.
           # For example, if using the `nullable` argument in a Terraform variable block, Terrascan throws an error. This argument was added in Terraform v1.1 (https://developer.hashicorp.com/terraform/language/values/variables#disallowing-null-input-values).
           VALIDATE_TERRAFORM_TERRASCAN: false
+          # For Python, prefer the Ruff linter over Flake8 and isort.
+          # The Ruff linter is faster than, has feature parity with, and serves as a drop-in replacement, for both Flake8 and isort.
+          # The Ruff formatter also has feature parity with Black, however Super-linter does not yet support the Ruff formatter.
+          # Ref: https://docs.astral.sh/ruff/
+          VALIDATE_PYTHON_FLAKE8: false
+          VALIDATE_PYTHON_ISORT: false


### PR DESCRIPTION
The Ruff linter is faster than, has feature parity with, and serves as a drop-in replacement for both Flake8 and isort.