### PR TITLE
feat(super-linter): create job summary instead of status checks

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -57,3 +57,7 @@ jobs:
           # For example, if using the nullable argument in a Terraform variable block, Terrascan throws an error.
           # This argument was added in Terraform v1.1 (ref: https://developer.hashicorp.com/terraform/language/values/variables#disallowing-null-input-values).
           VALIDATE_TERRAFORM_TERRASCAN: false
+          # Don't create status checks per linter.
+          # Create GitHub Actions job summary instead.
+          MULTI_STATUS: false
+          ENABLE_GITHUB_ACTIONS_STEP_SUMMARY: true

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -28,7 +28,6 @@ jobs:
     runs-on: ${{ inputs.runs_on }}
     permissions:
       contents: read # Required to checkout the repository
-      statuses: write # Required to report GitHub Actions status checks
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
Disable creation of status checks per linter. Instead, create a single status check for the entire linter workflow job, then create a job summary that lists all linters that were run.

This is to prevent an overly long list of status checks for pull requests that include many different languages to be linted.