### PR TITLE
fix(terraform): jobs that target different state files run in same concurrency group

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -72,9 +72,9 @@ on:
         description: A password used to encrypt the archive containing the Terraform configuration and plan file.
         required: true
 
-# Queue jobs that target the same Terraform configuration.
+# Queue jobs that target the same state file, i.e. the same working directory and backend configuration.
 concurrency:
-  group: terraform @ ${{ inputs.working_directory }}
+  group: terraform-${{ inputs.working_directory }}-${{ inputs.backend_config }}
   cancel-in-progress: false
 
 permissions: {}


### PR DESCRIPTION
Concurrency group should not be determined solely on the working directory, as it's possible to target the same working directory while using a partial backend configuration to target different Terraform state files.

Fixes #717