### PR TITLE
feat(terraform) create tag after running `terraform apply`

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -55,6 +55,11 @@ on:
         required: false
         default: true
 
+      tag_name:
+        description: The name of a tag to create after applying the Terraform plan.
+        type: string
+        required: false
+
     secrets:
       AZURE_CLIENT_ID:
         description: The client ID of the service principal to use for authenticating to Azure.
@@ -317,6 +322,14 @@ jobs:
 
       - name: Terraform Apply
         run: terraform apply -input=false "$PLAN_FILE"
+
+      - name: Create tag
+        if: inputs.tag_name != ''
+        env:
+          TAG_NAME: ${{ inputs.tag_name }}
+        run: |
+          git tag "$TAG_NAME"
+          git push origin "$TAG_NAME" 
 
       # Once the Terraform plan file has been applied, the artifact is no longer needed.
       # Delete it to save storage space.

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -329,7 +329,7 @@ jobs:
           TAG_NAME: ${{ inputs.tag_name }}
         run: |
           git tag "$TAG_NAME"
-          git push origin "$TAG_NAME" 
+          git push origin "$TAG_NAME"
 
       # Once the Terraform plan file has been applied, the artifact is no longer needed.
       # Delete it to save storage space.


### PR DESCRIPTION
After running `terraform apply`, create a tag with the given name. This should make it safer to use this workflow to run `terraform apply` from the default branch (instead of from pull request, which we usually recommend) as you can now use tags to keep track of which commits have been deployed for the Terraform configuration in the given working directory.

For example:

- Tag `core@dev` could be used to track which commit has been applied for Terraform configuration `terraform/dev/core`.
- Tag `core@prod` could be used to track which commit has been applied for Terraform configuration `terraform/prod/core`.

Fixes #722