### PR TITLE
feat: add workflow `terraform-test.yml`

### DIFF
--- a/.github/workflows/terraform-test.yml
+++ b/.github/workflows/terraform-test.yml
@@ -1,0 +1,118 @@
+name: ♻ terraform-test
+
+on:
+  workflow_call:
+    inputs:
+      runs_on:
+        description: The label of the runner (GitHub- or self-hosted) to run this workflow on. Defaults to `ubuntu-24.04`.
+        type: string
+        required: false
+        default: ubuntu-24.04
+
+      terraform_version:
+        description: The version of Terraform to install.
+        type: string
+        required: false
+        default: latest
+
+      test_filter:
+        description: Limit the `terraform test` operation to the specified test files.
+        type: string
+        required: false
+
+jobs:
+  terraform-test:
+    name: Terraform Test
+    runs-on: ${{ inputs.runs_on }}
+    env:
+      TF_IN_AUTOMATION: true
+      TEST_RESULTS_FILE: tftest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
+        with:
+          terraform_version: ${{ inputs.terraform_version }}
+          terraform_wrapper: false
+
+      - name: Terraform Format
+        id: fmt
+        run: terraform fmt -check
+
+      - name: Terraform Init
+        id: init
+        run: terraform init
+
+      - name: Terraform Validate
+        id: validate
+        run: terraform validate
+
+      - name: Terraform Test
+        id: test
+        # Ensure that the outcome of this step is "failure" when "terraform test" returns a non-zero exit code
+        shell: bash -o pipefail {0}
+        env:
+          TEST_FILTER: ${{ inputs.test_filter }}
+        run: |
+          optional_args=()
+          if [[ -n "$TEST_FILTER" ]]; then
+            optional_args+=(-filter="$TEST_FILTER")
+          fi
+          terraform test -json "${optional_args[@]}" | tee "$TEST_RESULTS_FILE"
+
+      - name: Create job summary
+        if: success() || failure()
+        shell: bash {0}
+        env:
+          TF_FMT_OUTCOME: ${{ steps.fmt.outcome }}
+          TF_INIT_OUTCOME: ${{ steps.init.outcome }}
+          TF_VALIDATE_OUTCOME: ${{ steps.validate.outcome }}
+          TF_TEST_OUTCOME: ${{ steps.test.outcome }}
+        run: |
+          tftest_results=$(cat "$TEST_RESULTS_FILE")
+          readarray -t tftest_array <<< "$tftest_results"
+
+          table_rows=("| Path | Run | Status | Details |")
+          table_rows+=("| --- | --- | --- | --- |")
+
+          for tftest_json in "${tftest_array[@]}"; do
+            type=$(jq -r '.type' <<<"$tftest_json")
+            test_run=$(jq -r '.test_run' <<<"$tftest_json")
+            progress=$(jq -r '.progress' <<<"$test_run")
+            path=$(jq -r '.path' <<<"$test_run")
+            run=$(jq -r '.run' <<<"$test_run")
+            status=$(jq -r '.status' <<<"$test_run")
+
+            if [[ "$type" != "test_run" ]] || [[ "$progress" != "complete" ]]; then
+              continue
+            fi
+
+            status_emoji="heavy_minus_sign" # neutral/unknown by default
+            if [[ "$status" == "pass" ]]; then
+              status_emoji="heavy_check_mark"
+            elif [[ "$status" == "fail" ]] || [[ "$status" == "error" ]]; then
+              status_emoji="x"
+            fi
+
+            error_details=$(jq -r --arg testfile "$path" --arg testrun "$run" 'select(."@level"=="error" and ."@testfile"==$testfile and ."@testrun"==$testrun) | .diagnostic.detail' <<<"$tftest_results")
+            details=${error_details//$'\n'/<br>}
+            table_rows+=("| \`$path\` | \`$run\` | :$status_emoji:**\`$status\`** | $details |")
+          done
+
+          table=$(printf "%s\n" "${table_rows[@]}")
+
+          echo "#### Terraform Format and Style 🖌\`$TF_FMT_OUTCOME\`
+          #### Terraform Initialization ⚙\`$TF_INIT_OUTCOME\`
+          #### Terraform Validation 🤖\`$TF_VALIDATE_OUTCOME\`
+          #### Terraform Test 🧪\`$TF_TEST_OUTCOME\`
+
+          <details><summary>Show Tests</summary>
+
+          $table
+
+          </details>
+
+          *Pusher: @$GITHUB_ACTOR, Action: \`$GITHUB_EVENT_NAME\`, Workflow: \`$GITHUB_WORKFLOW\`*" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Add a reusable workflow for running infrastructure tests using the Terraform Test framework. Test results are presented in a job summary similar to the one created by the `terraform.yml` workflow.

An almost direct copy of the Terraform Test workflow in [Terraform Baseline](https://github.com/equinor/terraform-baseline/blob/cd1dbe917d4a71a1d3098da13294d5abaa7ec1af/.github/workflows/terraform-test.yml).

The idea is to move that workflow here so that all reusable workflows are collected in a single repository.

When this workflow was originally implemented in the Terraform Baseline repository, the `terraform test` command only supported the `-json` option for displaying results in a format that could be parsed in automation. As a result, this workflow currently uses `jq` to parse the test results and format it in a Markdown table to be displayed in the job summary.

Since then, the `terraform test` command has added support for a new option `-junit-xml` (a standardized format for storing test results), which could potentially replace the custom JSON parsing that we currently do.