### PR TITLE
chore: add notes on runner image versions

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -77,7 +77,8 @@ Written as an extension of [Security hardening for GitHub Actions](https://docs.
       runs-on: ubuntu-24.04
   ```
 
-  This ensures that all jobs are executed on a runner that includes the required software by default.
+  This ensures that all jobs are executed on a runner that includes the required software by default.  
+  **Please note: While a specific runner version ensures a consistent environment, some pre-installed packages may still be updated over time to address bugs or other issues. As a result, the exact package versions may vary.**
 
 - Workflows that run [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/) commands should declare the following top level environment variable to disable output from Azure CLI commands by default:
 


### PR DESCRIPTION
Added a note after running into this bug: https://github.com/Azure/azure-cli/issues/31591
Discovered that Azure CLI had been updated in the ubuntu-24-04 image to fix the bug.