### PR TITLE
feat(terraform): validate configuration if triggered by Dependabot

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -58,15 +58,15 @@ on:
     secrets:
       AZURE_CLIENT_ID:
         description: The client ID of the service principal to use for authenticating to Azure.
-        required: true
+        required: false
 
       AZURE_SUBSCRIPTION_ID:
         description: The ID of the Azure subscription to authenticate to.
-        required: true
+        required: false
 
       AZURE_TENANT_ID:
         description: The ID of the Microsoft Entra tenant to authenticate to.
-        required: true
+        required: false
 
       GRAFANA_AUTH:
         description: A service account token to use for authenticating to Grafana.

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -110,7 +110,6 @@ jobs:
   terraform-plan:
     name: Terraform Plan
     runs-on: ${{ inputs.runs_on }}
-    if: github.actor != 'dependabot[bot]'
     environment: ${{ inputs.environment }}
     permissions:
       contents: read # Required to checkout the repository
@@ -179,7 +178,9 @@ jobs:
           BACKEND_CONFIG: ${{ inputs.backend_config }}
         run: |
           optional_args=()
-          if [[ -n "$BACKEND_CONFIG" ]]; then
+          if [[ "$GITHUB_ACTOR" == "dependabot[bot]" ]]; then
+            optional_args+=(-backend=false)
+          elif [[ -n "$BACKEND_CONFIG" ]]; then
             optional_args+=(-backend-config="$BACKEND_CONFIG")
           fi
           terraform init -input=false "${optional_args[@]}"
@@ -194,6 +195,7 @@ jobs:
       # Ref: https://developer.hashicorp.com/terraform/tutorials/automation/automate-terraform#plan-and-apply-on-different-machines
       - name: Terraform Plan
         id: plan
+        if: github.actor != 'dependabot[bot]'
         # Start Bash without fail-fast behavior.
         # Required in order to check exitcode.
         # Ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
@@ -284,7 +286,7 @@ jobs:
   terraform-apply:
     name: Terraform Apply
     needs: terraform-plan
-    if: github.actor != 'dependabot[bot]' && needs.terraform-plan.outputs.upload-outcome == 'success' && inputs.run_terraform_apply
+    if: needs.terraform-plan.outputs.upload-outcome == 'success' && inputs.run_terraform_apply
     runs-on: ${{ inputs.runs_on }}
     environment: ${{ inputs.environment }}
     permissions:


### PR DESCRIPTION
This change was originally implemented in 9d552d9811de33b0ce670c4bddbd39fc083ddc0e.

It was then reverted in 1ef1222411f03b3a8b74949e1d461b72b5f29012 since it required explicit configuration of Dependabot-specific secrets `AZURE_CLIENT_ID`, `AZURE_SUBSCRIPTION_ID` and `AZURE_TENANT_ID`, which broke any workflow runs triggered by Dependabot unless these secrets had been explicitly configured.

This new implementation is identical to the original, except that secrets `AZURE_CLIENT_ID`, `AZURE_SUBSCRIPTION_ID` and `AZURE_TENANT_ID` have been marked as optional, which means that Dependabot will be able to run `terraform validate` without having to pass values for these secrets.

These secrets used to be required since the workflow only supported authenticating the Azure provider, however since we added support for authenticating the Grafana provider in 256e5e6e2383933a9b28a549aea55c27e019ea71 it's OK to mark the Azure-related secrets as optional.