### PR TITLE
chore: upgrade release-please workflow to 4.3.0

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,6 +26,6 @@ jobs:
       pull-requests: write # Required to create release PRs
     steps:
       - name: Release Please
-        uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445
+        uses: googleapis/release-please-action@c2a5a2bd6a758a0937f1ddb1e8950609867ed15c
         with:
           release-type: ${{ inputs.release_type }}


### PR DESCRIPTION
Upgrades `googleapis/release-please-action` to 4.3.0 to address [googleapis/release-please-action#867](https://github.com/googleapis/release-please-action/issues/867)