### PR TITLE
feat: disable Git credential persistance

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -61,6 +61,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020

--- a/.github/workflows/databricks-bundle.yml
+++ b/.github/workflows/databricks-bundle.yml
@@ -69,6 +69,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          persist-credentials: false
 
       - name: Setup Databricks CLI
         uses: databricks/setup-cli@502ac09613c7ca0eda68838be2f1b27b0e8bb7ac

--- a/.github/workflows/docker-acr.yml
+++ b/.github/workflows/docker-acr.yml
@@ -76,6 +76,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          persist-credentials: false
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -74,6 +74,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          persist-credentials: false
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@4fd812986e6c8c2a69e18311145f9371337f27d4

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -79,6 +79,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9

--- a/.github/workflows/mkdocs-gh-pages.yml
+++ b/.github/workflows/mkdocs-gh-pages.yml
@@ -43,6 +43,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -51,6 +51,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -62,6 +62,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -70,6 +70,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           fetch-depth: 0 # Required to get the list of files that changed across commits
+          persist-credentials: false
 
       - name: Lint Codebase
         uses: super-linter/super-linter@ffde3b2b33b745cb612d787f669ef9442b1339a6

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -121,6 +121,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          persist-credentials: false
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
@@ -300,6 +302,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          persist-credentials: false
 
       - name: Download artifact
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -38,7 +38,7 @@ Written as an extension of [Security hardening for GitHub Actions](https://docs.
         contents: read # Required to checkout the repository
       steps:
         - name: Checkout
-          uses: actions/checkout@v4
+          uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
           with:
             persist-credentials: false
   ```
@@ -87,7 +87,7 @@ Written as an extension of [Security hardening for GitHub Actions](https://docs.
   ```yaml
   steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
       with:
         persist-credentials: false
   ```
@@ -157,7 +157,7 @@ Written as an extension of [Security hardening for GitHub Actions](https://docs.
       runs-on: ${{ inputs.runs_on }}
       steps:
         - name: Checkout
-          uses: actions/checkout@v4
+          uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
           with:
             persist-credentials: false
 

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -82,6 +82,16 @@ Written as an extension of [Security hardening for GitHub Actions](https://docs.
   This ensures that all jobs are executed on a runner that includes the required software by default.  
   **Please note: While a specific runner version ensures a consistent environment, some pre-installed packages may still be updated over time to address bugs or other issues. As a result, the exact package versions may vary.**
 
+- Steps that use the [actions/checkout](https://github.com/actions/checkout) action should disable credential persistence unless explicitly required:
+
+  ```yaml
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+  ```
+
 - Workflows that run [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/) commands should declare the following top level environment variable to disable output from Azure CLI commands by default:
 
   ```yaml

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -39,6 +39,8 @@ Written as an extension of [Security hardening for GitHub Actions](https://docs.
       steps:
         - name: Checkout
           uses: actions/checkout@v4
+          with:
+            persist-credentials: false
   ```
 
   This ensures that workflows follow the principle of least privilege.
@@ -146,6 +148,8 @@ Written as an extension of [Security hardening for GitHub Actions](https://docs.
       steps:
         - name: Checkout
           uses: actions/checkout@v4
+          with:
+            persist-credentials: false
 
         - name: Setup Python
           uses: actions/setup-python@v5

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -110,13 +110,11 @@ Written as an extension of [Security hardening for GitHub Actions](https://docs.
 - Use [SCREAMING_SNAKE_CASE](https://en.wiktionary.org/wiki/snake_case) for environment variable names.
 
 - A reusable workflow and its main job should be named after the main tool/service that is used, for example:
-
   - `terraform.yml`
   - `docker.yml`
   - `azure-webapp.yml`
 
   This is to ensure descriptive job names, for example:
-
   - If a caller workflow has a job `provision` that calls the reusable workflow `terraform`, the final job will be named `provision / terraform`.
   - If a caller workflow has a job `build` that calls the reusable workflow `docker`, the final job will be named `build / docker`.
   - If a caller workflow has a job `deploy` that calls the reusable workflow `azure-webapp`, the final job will be named `deploy / azure-webapp`.


### PR DESCRIPTION
If the value of input `persist-credentials` is set to `true`, the `actions/checkout` action will authenticate Git. The auth token is persisted in the local Git config.

If a workflow does not explicitly need Git to be authenticated, persisting the token poses a potential security risk. By setting the value of this input to `false`, we opt-out of this behavior.