### PR TITLE
fix(docker): pin `docker/setup-buildx-action` action to commit SHA

### DIFF
--- a/.github/workflows/docker-acr.yml
+++ b/.github/workflows/docker-acr.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
 
       - name: Login to Azure
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -76,7 +76,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@4fd812986e6c8c2a69e18311145f9371337f27d4
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
 
       - name: Login to Docker registry
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1


### PR DESCRIPTION
In `docker-acr.yml`, pin `docker/setup-buildx-action` action to commit SHA.

In `docker.yml`, pin `docker/setup-buildx-action` action to same commit SHA as in `docker-acr.yml`. Previous commit SHA is not associated with a release, which seems to have broken Release-Please updates for this specific action.