### PR TITLE
fix(docker): prevent code injection via template expression

### DIFF
--- a/.github/workflows/docker-acr.yml
+++ b/.github/workflows/docker-acr.yml
@@ -99,7 +99,7 @@ jobs:
         env:
           DOCKER_BUILD_SUMMARY: true
         with:
-          context: ${{ inputs.working_directory }}
+          file: ${{ inputs.working_directory }}/Dockerfile
           tags: ${{ env.IMAGE }},${{ env.IMAGE_LATEST }}
           push: true
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -93,7 +93,7 @@ jobs:
           DOCKER_BUILD_SUMMARY: true
         with:
           build-args: ${{ inputs.build_args }}
-          context: ${{ inputs.working_directory }}
+          file: ${{ inputs.working_directory }}/Dockerfile
           tags: ${{ env.IMAGE }},${{ env.IMAGE_LATEST }}
           push: true
 


### PR DESCRIPTION
According to the `zizmor` linter, the `context` input for the `docker/build-push-action` action accepts arbitrary code, and could be used to inject malicious code. To remediate this vulnerability, replace the use of the `context` input in the `docker.yml` and `docker-acr.yml` workflows with the `file` input.

After making this change, running `zizmor` reports no known vulnerabilities for the `docker.yml` and `docker-acr.yml` workflows:

```console
$ zizmor docker.yml
 INFO zizmor::registry: skipping impostor-commit: can't run without a GitHub API token
 INFO zizmor::registry: skipping ref-confusion: can't run without a GitHub API token
 INFO zizmor::registry: skipping known-vulnerable-actions: can't run without a GitHub API token
 INFO zizmor::registry: skipping forbidden-uses: audit not configured
 INFO zizmor::registry: skipping stale-action-refs: can't run without a GitHub API token
 INFO audit: zizmor: 🌈 completed docker.yml
No findings to report. Good job!
```

```console
$ zizmor docker-acr.yml
 INFO zizmor::registry: skipping impostor-commit: can't run without a GitHub API token
 INFO zizmor::registry: skipping ref-confusion: can't run without a GitHub API token
 INFO zizmor::registry: skipping known-vulnerable-actions: can't run without a GitHub API token
 INFO zizmor::registry: skipping forbidden-uses: audit not configured
 INFO zizmor::registry: skipping stale-action-refs: can't run without a GitHub API token
 INFO audit: zizmor: 🌈 completed docker-acr.yml
No findings to report. Good job!
```

Fixes #753