### PR TITLE
fix(release-please): remove default release type

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,10 +10,9 @@ on:
         default: ubuntu-24.04
 
       release_type:
-        description: The type of release to create (see [supported release types](https://github.com/googleapis/release-please/blob/main/README.md#strategy-language-types-supported)). Defaults to `simple`.
+        description: The type of release to create (see [supported release types](https://github.com/googleapis/release-please/blob/main/README.md#strategy-language-types-supported)).
         type: string
         required: false
-        default: simple
 
 permissions: {}
 


### PR DESCRIPTION
Breaks monorepo releases by default, i.e. repos that use a `release-please-config.json` file to configure multiple packages to be released in a single repo.

Not a breaking change since Release Please assumes a simple release by default.