### PR TITLE
refactor: rename workflow `uv-release-please.yml` to `python-release.yml`

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -1,4 +1,4 @@
-name: ♻ uv-release-please
+name: ♻ python-release
 
 on:
   workflow_call:

--- a/docs/workflows/python-release.md
+++ b/docs/workflows/python-release.md
@@ -1,6 +1,6 @@
 # Python Package Releaser
 
-[Python Package Releaser](../../.github/workflows/uv-release-please.yml) is a reusable GitHub Actions workflow that automatically builds and releases your Python packages using modern tooling:
+[Python Package Releaser](../../.github/workflows/python-release.yml) is a reusable GitHub Actions workflow that automatically builds and releases your Python packages using modern tooling:
 
 - [uv](https://docs.astral.sh/uv/) for Python package management
 - [Release Please](https://github.com/googleapis/release-please) for GitHub release automation
@@ -68,7 +68,7 @@ on:
 
 jobs:
   build:
-    uses: equinor/ops-actions/.github/workflows/uv-release-please.yml@main
+    uses: equinor/ops-actions/.github/workflows/python-release.yml@main
     with:
       uv_version: 0.8.15
     permissions:


### PR DESCRIPTION
Use a more generic name to open possibility of swapping tools used under the hood in the future.

This *should* be a breaking change, but since we're doing this right after the initial release of this workflow, I'm marking it as a simple early refactor.

Release-As: 9.24.1