### PR TITLE
fix(docker-acr): fix context input

### DIFF
--- a/.github/workflows/docker-acr.yml
+++ b/.github/workflows/docker-acr.yml
@@ -100,6 +100,7 @@ jobs:
           DOCKER_BUILD_SUMMARY: true
         with:
           file: ${{ inputs.working_directory }}/Dockerfile
+          context: ${{ inputs.working_directory }}
           tags: ${{ env.IMAGE }},${{ env.IMAGE_LATEST }}
           push: true
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -94,6 +94,7 @@ jobs:
         with:
           build-args: ${{ inputs.build_args }}
           file: ${{ inputs.working_directory }}/Dockerfile
+          context: ${{ inputs.working_directory }}
           tags: ${{ env.IMAGE }},${{ env.IMAGE_LATEST }}
           push: true
 


### PR DESCRIPTION
Skipping `context` input defaults it to [Git Context](https://github.com/docker/build-push-action/tree/263435318d21b8e681c14492fe198d362a7d2c83/?tab=readme-ov-file#git-context). In previous builds, `context` was equal to `${{ inputs.working_dir }}`