### PR TITLE
fix(python-release): add required workflow permission

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -28,6 +28,7 @@ jobs:
     runs-on: ${{ inputs.runs_on }}
     permissions:
       contents: write # Required to update changelog files.
+      issues: write # Required to label issues.
       pull-requests: write # Required to create release PRs.
     steps:
       - name: Release Please

--- a/docs/workflows/python-release.md
+++ b/docs/workflows/python-release.md
@@ -73,6 +73,7 @@ jobs:
       uv_version: 0.8.15
     permissions:
       contents: write
+      issues: write
       pull-requests: write
 
 ```


### PR DESCRIPTION
As specified in the [Release-please action README](https://github.com/googleapis/release-please-action/blob/c2a5a2bd6a758a0937f1ddb1e8950609867ed15c/README.md#workflow-permissions).