### PR TITLE
fix(docker): prevent code injection via template expression

### DIFF
--- a/.github/workflows/docker-acr.yml
+++ b/.github/workflows/docker-acr.yml
@@ -73,6 +73,9 @@ jobs:
     env:
       IMAGE: ${{ inputs.registry_name }}.azurecr.io/${{ inputs.repository }}:${{ inputs.tag }}
       IMAGE_LATEST: ${{ inputs.registry_name }}.azurecr.io/${{ inputs.repository }}:latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
@@ -94,15 +97,8 @@ jobs:
           REGISTRY_NAME: ${{ inputs.registry_name }}
         run: az acr login --name "$REGISTRY_NAME"
 
-      - name: Build and push
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
-        env:
-          DOCKER_BUILD_SUMMARY: true
-        with:
-          file: ${{ inputs.working_directory }}/Dockerfile
-          context: ${{ inputs.working_directory }}
-          tags: ${{ env.IMAGE }},${{ env.IMAGE_LATEST }}
-          push: true
+      - name: Docker Build
+        run: docker buildx build --tag "$IMAGE" --tag "$IMAGE_LATEST" --push .
 
     outputs:
       image: ${{ env.IMAGE }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -87,16 +87,8 @@ jobs:
           username: ${{ inputs.username }}
           password: ${{ secrets.password }}
 
-      - name: Build and push
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
-        env:
-          DOCKER_BUILD_SUMMARY: true
-        with:
-          build-args: ${{ inputs.build_args }}
-          file: ${{ inputs.working_directory }}/Dockerfile
-          context: ${{ inputs.working_directory }}
-          tags: ${{ env.IMAGE }},${{ env.IMAGE_LATEST }}
-          push: true
+      - name: Docker Build
+        run: docker buildx build --tag "$IMAGE" --tag "$IMAGE_LATEST" --push .
 
     outputs:
       image: ${{ env.IMAGE }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -71,6 +71,9 @@ jobs:
     env:
       IMAGE: ${{ inputs.registry }}/${{ inputs.repository }}:${{ inputs.tag }}
       IMAGE_LATEST: ${{ inputs.registry }}/${{ inputs.repository }}:latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8


### PR DESCRIPTION
Replace `docker/build-push-action` action with corresponding `docker buildx build` CLI command, preventing possible code injection via template expression through the use of the `context` input.

Fixes #769.