### PR TITLE
docs(python-release): clarify usability of workflow

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -49,11 +49,8 @@ jobs:
     runs-on: ${{ inputs.runs_on }}
     environment: ${{ inputs.environment }}
     permissions:
-      # Read permission required to checkout the repository.
-      # Write permission required to upload the release artifact.
-      contents: write
-      # Write permissions required for PyPI Trusted Publishing.
-      id-token: write
+      contents: read # Required to checkout the repository.
+      id-token: write # Required for PyPI Trusted Publishing.
     defaults:
       run:
         shell: bash

--- a/docs/workflows/python-release.md
+++ b/docs/workflows/python-release.md
@@ -1,7 +1,7 @@
 # `python-release.yml`
 
 > [!IMPORTANT]
-> This workflow is still in active development - breaking changes may be implemented in the future.
+> This workflow uses [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/). This feature currently does not support publishing from a reusable workflow. Until this feature is officially supported (see [pypi/warehouse#11096](https://github.com/pypi/warehouse/issues/11096) for status), this reusable workflow serves as a working reference.
 
 A reusable GitHub Actions workflow that automatically builds and releases your Python packages.
 


### PR DESCRIPTION
Clarify that the `python-release.yml` workflow currently doesn't work as expected due to a limitation in PyPI, so it currently only serves as a working reference.

Also reduce job permissions, as `contents: write` is no longer needed. This has been verified to work in the [dataorc project](https://github.com/equinor/dataorc/blob/1612401d812a09faaa92d6600e4dac1644d833c8/.github/workflows/release.yml).