### PR TITLE
feat(mkdocs): install Python version specified in `.python-version` file

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -10,10 +10,9 @@ on:
         default: ubuntu-24.04
 
       python_version:
-        description: The version of Python to install.
+        description: The version of Python to install. Defaults to the version specified in the `.python-version` file.
         type: string
         required: false
-        default: latest
 
       mkdocs_version:
         description: The version of MkDocs to install using pip.


### PR DESCRIPTION
Support the standard of installing the Python version specified in a `.python-version` file. You can still specify a version using the `python_version` input if you want to.