### PR TITLE
feat(mkdocs): add input `upload_artifact`

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -26,8 +26,14 @@ on:
         type: string
         required: false
 
+      upload_artifact:
+        description: Should the MkDocs build artifact be uploaded? Defaults to `true`.
+        type: boolean
+        required: false
+        default: true
+
       artifact_name:
-        description: The name of the artifact to upload.
+        description: The name of the artifact to upload. Defaults to `mkdocs`.
         type: string
         required: false
         default: mkdocs
@@ -77,6 +83,7 @@ jobs:
 
       - name: Create tarball
         id: tar
+        if: inputs.upload_artifact
         working-directory: ${{ env.SITE_DIR }}
         run: |
           tarball="$RUNNER_TEMP/$ARTIFACT_NAME.tar"
@@ -84,6 +91,7 @@ jobs:
           echo "tarball=$tarball" >> "$GITHUB_OUTPUT"
 
       - name: Upload artifact
+        if: inputs.upload_artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: ${{ inputs.artifact_name }}


### PR DESCRIPTION
Add an input to control whether or not the MkDocs build artifact should be uploaded.

For example, use this input to only upload artifact on push to main. This would allow the workflow to run on PR, to verify that the MkDocs builds, without taking up GitHub storage space.