### PR TITLE
chore: include Dependabot updates in releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,6 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    # Prefix commit messages with "fix(deps)" to include dependency updates in patch releases
+    commit-message:
+      prefix: fix(deps)


### PR DESCRIPTION
Configure Dependabot to prefix commit messages with `fix(deps)` to include dependency updates in patch releases created by Release Please.

This is how the Release Please team themselves do it ([ref.](https://github.com/googleapis/release-please/pulls?q=is%3Apr+is%3Aclosed+fix%28deps%29)).

Fixes #801.