### PR TITLE
feat(python-package): toggle whether build artifact should be uploaded

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,15 +22,25 @@ on:
         default: "."
 
       artifact_name:
-        description: The name of the build artifact to upload. Defaults to `python-package-dist`.
+        description: The name of the build artifact. Defaults to `python-package-dist`.
         type: string
         required: false
         default: python-package-dist
 
+      upload_artifact:
+        description: Should the build artifact be uploaded? Defaults to `true`.
+        type: boolean
+        required: false
+        default: true
+
     outputs:
       artifact_name:
-        description: The name of the uploaded build artifact.
+        description: The name of the build artifact.
         value: ${{ inputs.artifact_name }}
+
+      artifact_uploaded:
+        description: Was the build artifact uploaded? Value is `"true"` if the build artifact was uploaded, else `"false"`.
+        value: ${{ jobs.python-build.outputs.artifact-uploaded }}
 
 permissions: {}
 
@@ -62,10 +72,15 @@ jobs:
         run: python -m build
 
       - name: Upload artifact
+        id: upload-artifact
+        if: ${{ inputs.upload_artifact }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: ${{ inputs.artifact_name }}
           path: ${{ inputs.working_directory }}/dist
+
+    outputs:
+      artifact-uploaded: ${{ steps.upload-artifact.outcome == 'success' }}
 
   # Reusable workflows are currently not supported for PyPI Trusted Publishing.
   # Ref: https://docs.pypi.org/trusted-publishers/troubleshooting/#reusable-workflows-on-github
@@ -73,6 +88,7 @@ jobs:
   # pypi-publish:
   #   name: PyPI Publish
   #   needs: python-build
+  #   if: needs.python-build.outputs.artifact-uploaded
   #   runs-on: ${{ inputs.runs_on }}
   #   environment: ${{ inputs.environment }}
   #   permissions:

--- a/docs/workflows/python-package.md
+++ b/docs/workflows/python-package.md
@@ -83,7 +83,21 @@ The path of the directory containing the Python project to build. Defaults to `.
 
 ### (*Optional*) `artifact_name`
 
-The name of the build artifact to upload. Defaults to `python-package-dist`.
+The name of the build artifact. Defaults to `python-package-dist`.
+
+### (*Optional*) `upload_artifact`
+
+Should the build artifact be uploaded? Defaults to `true`.
+
+## Outputs
+
+### `artifact_name`
+
+The name of the build artifact.
+
+### `artifact_uploaded`
+
+Was the build artifact uploaded? Value is `"true"` if the build artifact was uploaded, else `"false"`.
 
 ## References
 


### PR DESCRIPTION
- Add input `upload_artifact` that allows toggling if the artifact should be uploaded or not.
- Add output `artifact_uploaded` that returns `"true"` if the build artifact was uploaded, else `"false"`.

Also modified the commented out `pypi-publish` job to only run if the artifact was uploaded (i.e., there is a build artifact to be published).