### PR TITLE
docs: clarify versioning convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ The [GitHub Actions extension for Visual Studio Code](https://marketplace.visual
 
 We perform [user acceptance tests](https://en.wikipedia.org/wiki/Acceptance_testing#User_acceptance_testing) for reusable workflows.
 
+## Versioning
+
+This project follows [Semantic Versioning](https://semver.org/).
+
 ## Contributing
 
 See [contributing guidelines](CONTRIBUTING.md).


### PR DESCRIPTION
Clarify that the ops-actions project follows the [Semantic Versioning](https://semver.org/) convention.

Small change, but I've seen other projects that highlight their versioning convention in their README (e.g., [Release Please](https://github.com/googleapis/release-please/blob/869e3eef97a8e6f4b965ccfc2a0ef5d2414adfab/README.md#versioning)), and I think it's a good practice to ensure the README contains as much information as possible that will help people get started using the project.