### PR TITLE
fix(docker-acr): login to Azure fails with data plane-only access

### DIFF
--- a/.github/workflows/docker-acr.yml
+++ b/.github/workflows/docker-acr.yml
@@ -43,13 +43,13 @@ on:
         description: The client ID of the service principal to use for authenticating to Azure.
         required: true
 
-      AZURE_TENANT_ID:
-        description: The ID of the Microsoft Entra tenant to authenticate to.
-        required: true
-
       AZURE_SUBSCRIPTION_ID:
         description: (Deprecated) The ID of an Azure subscription to authenticate to.
         required: false
+
+      AZURE_TENANT_ID:
+        description: The ID of the Microsoft Entra tenant to authenticate to.
+        required: true
 
     outputs:
       image:


### PR DESCRIPTION
Add input `allow-no-subscriptions` to the `azure/login` action to, allowing us to set workflow input `AZURE_SUBSCRIPTION_ID` as optional.

This allows the use of service principals that only have access to the ACR data plane through a role like `AcrPush` - a scenario that fails with the current implementation of this workflow, due to its requirement of authenticating to an Azure subscription at the control plane.

With this change, the `AZURE_SUBSCRIPTION_ID` input is technically deprecated, since it no longer has any function. I have updated the description of the input to reflect this. We should not remove the input (yet), since that would be a breaking change.