### PR TITLE
feat(mkdocs): enable optional strict mode

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -99,7 +99,7 @@ jobs:
           STRICT_MODE: ${{ inputs.strict_mode }}
         run: |
           optional_args=()
-          if [[ "$STRICT_MODE" ]]; then
+          if [[ "$STRICT_MODE" == "true" ]]; then
             optional_args+=(--strict)
           fi
           mkdocs build --site-dir "$SITE_DIR" "${optional_args[@]}"


### PR DESCRIPTION
Enabling strict mode causes MkDocs to abort build on any warnings.

For example, enable strict mode on pull request trigger to ensure all warnings are resolved before merging to main.

Setting default value to `false` to make it backward compatible with older versions of the workflow that don't have strict mode enabled.