### PR TITLE
ci: replace Super-linter with zizmor

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,9 +1,6 @@
 name: Lint
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
- In the `lint.yml` workflow file, replace the Super-linter with a zizmor job that integrates with CodeQL
- Add `permissions` at both workflow and job level to resolve potential problems reported by zizmor (which means that zizmor is doing its job!)

