### PR TITLE
ci: create separate workflow for linting PRs

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,20 @@
+name: Lint Pull Request
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions: {}
+
+jobs:
+  lint-pr:
+    name: Lint PR Title
+    permissions:
+      contents: read
+    uses: ./.github/workflows/commitlint.yml
+    with:
+      message: ${{ github.event.pull_request.title }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,14 +1,10 @@
-name: Lint
+name: Lint Codebase
 
 on:
+  push:
+    branches: [main]
   pull_request:
-    branches:
-      - main
-    types:
-      - opened
-      - edited
-      - synchronize
-      - reopened
+    branches: [main]
 
 permissions: {}
 
@@ -20,11 +16,3 @@ jobs:
       security-events: write
       actions: read
     uses: ./.github/workflows/zizmor-codeql.yml
-
-  lint-pr:
-    name: Lint PR
-    permissions:
-      contents: read
-    uses: ./.github/workflows/commitlint.yml
-    with:
-      message: ${{ github.event.pull_request.title }}


### PR DESCRIPTION
Currently, we lint both the codebase and PR titles in the same workflow. As a result, both jobs will have the same triggers, e.g., the entire codebase will be linted when we simply edit the PR title or description.

Split the PR lint job into a separate workflow `lint-pr.yml`, allowing us to use more granular triggers in both the `lint.yml` and `lint-pr.yml` workflows.