### PR TITLE
fix(zizmor-codeql): exit with error if config file not found

### DIFF
--- a/.github/workflows/zizmor-codeql.yml
+++ b/.github/workflows/zizmor-codeql.yml
@@ -32,10 +32,11 @@ jobs:
         run: |
           optional_args=()
 
-          if [[ -n "$CONFIG_FILE" ]]; then
+          if [[ -f "$CONFIG_FILE" ]]; then
             optional_args+=(--config "$CONFIG_FILE")
-          elif [[ -f "$CONFIG_FILE" ]]; then
-            optional_args+=(--config "$CONFIG_FILE")
+          elif [[ -n "$CONFIG_FILE" ]]; then
+            echo "Config file '$CONFIG_FILE' not found" >&2
+            exit 1
           fi
 
           uvx zizmor --format=sarif "${optional_args[@]}" . > results.sarif


### PR DESCRIPTION
If input `config_file` contains a non-zero value that is not a file path, print an error message to stderr then exit with status code 1.