### PR TITLE
chore: add deploy key script

### DIFF
--- a/scripts/add_deploy_key.sh
+++ b/scripts/add_deploy_key.sh
@@ -16,7 +16,7 @@
 #   PRIVATE_REPO: Private repository to add the deploy key
 #
 # Usage:
-#   ./add-deploy-key.sh <OWNER> <REPO> <PRIVATE_REPO>
+#   ./add_deploy_key.sh <OWNER> <REPO> <PRIVATE_REPO>
 
 set -eu
 


### PR DESCRIPTION
Add a script that adds a deploy key to a specified private repository, enabling GitHub Actions workflows in a target repository to pull the private repository.

The use of this script will be recommended for users who need to download Terraform modules from private GitHub repositories (#861).