### PR TITLE
fix(commitlint): workflow fails if triggered by non-push event

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -53,7 +53,7 @@ jobs:
     env:
       COMMITLINT_VERSION: ${{ inputs.commitlint_version }}
       EXTENDS_JSON: ${{ inputs.extends }}
-      COMMIT_MESSAGE: ${{ inputs.message }}
+      MESSAGE: ${{ inputs.message }}
       BASE_SHA: ${{ github.event.pull_request.base.sha }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       HELP_URL: ${{ inputs.help_url }}
@@ -81,7 +81,7 @@ jobs:
 
           optional_args=()
 
-          if [[ -n "$COMMIT_MESSAGE" ]]; then
+          if [[ -n "$MESSAGE" ]]; then
             echo "Linting commit message from stdin" >&2
           elif [[ -n "$BASE_SHA" && -n "$HEAD_SHA" ]]; then
             echo "Linting commit range" >&2
@@ -91,4 +91,4 @@ jobs:
             optional_args+=(--last)
           fi
 
-          npx "commitlint@$COMMITLINT_VERSION" --extends "${extends[@]}" --help-url "$HELP_URL" --verbose "${optional_args[@]}" <<< "$COMMIT_MESSAGE"
+          npx "commitlint@$COMMITLINT_VERSION" --extends "${extends[@]}" --help-url "$HELP_URL" --verbose "${optional_args[@]}" <<< "$MESSAGE"


### PR DESCRIPTION
Only the push event contains a `head_commit` property in its payload (https://docs.github.com/en/webhooks/webhook-events-and-payloads). As a result, the default value `${{ github.event.head_commit.message }}` for input `message` currently throws an error if this workflow is triggered by a non-push event.

To fix this issue while ensuring backwards compatability with existing versions of this workflow, remove the default value and add the `--last` parameter to the `commitlint` command by default. The `actions/checkout` will checkout the repository (default branch for events that don't specify a ref), then commitlint will lint the last commit message in the checked out repository.

Using the `--last` parameter does not work when triggered by a pull request, so in that scenario we have to to add the `--from` and `--to` parameters to lint all commits in the pull request.

This is the setup that the commitlint developers themselves recommend in their setup guide for GitHub Actions: https://commitlint.js.org/guides/ci-setup.html#github-actions

Also added the `--verbose` parameter, which ensures the commit message linted by commitlint is always printed in the log output. If this parameter is not added, then the commit message will only be printed if commitlint exits with an error.

