### PR TITLE
refactor(python-package): use uv to generate distributions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,6 +21,11 @@ on:
         required: false
         default: "."
 
+      uv_version:
+        description: The version of uv to install. Defaults to the version in `pyproject.toml` or `latest`.
+        type: string
+        required: false
+
       artifact_name:
         description: The name of the build artifact. Defaults to `python-package-dist`.
         type: string
@@ -40,13 +45,13 @@ on:
 
       artifact_uploaded:
         description: Was the build artifact uploaded? Value is `"true"` if the build artifact was uploaded, else `"false"`.
-        value: ${{ jobs.python-build.outputs.artifact-uploaded }}
+        value: ${{ jobs.python-package.outputs.artifact-uploaded }}
 
 permissions: {}
 
 jobs:
-  python-build:
-    name: Python Build
+  python-package:
+    name: Python Package
     runs-on: ${{ inputs.runs_on }}
     permissions:
       contents: read # Required to checkout the repository.
@@ -65,11 +70,13 @@ jobs:
         with:
           python-version-file: .python-version
 
-      - name: Install dependencies
-        run: python -m pip install --upgrade pip build
+      - name: Setup uv
+        uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41
+        with:
+          version: ${{ inputs.uv_version }}
 
       - name: Generate distributions
-        run: python -m build
+        run: uv build
 
       - name: Upload artifact
         id: upload-artifact
@@ -87,8 +94,8 @@ jobs:
 
   # pypi-publish:
   #   name: PyPI Publish
-  #   needs: python-build
-  #   if: needs.python-build.outputs.artifact-uploaded
+  #   needs: python-package
+  #   if: needs.python-package.outputs.artifact-uploaded
   #   runs-on: ${{ inputs.runs_on }}
   #   environment: ${{ inputs.environment }}
   #   permissions:

--- a/docs/workflows/python-package.md
+++ b/docs/workflows/python-package.md
@@ -137,6 +137,10 @@ The label of the runner (GitHub- or self-hosted) to run this workflow on. Defaul
 
 The path of the directory containing the Python project to build. Defaults to `.`.
 
+### (*Optional*) `uv_version`
+
+The version of uv to install. Defaults to the version in `pyproject.toml` or `latest`.
+
 ### (*Optional*) `artifact_name`
 
 The name of the build artifact. Defaults to `python-package-dist`.
@@ -159,3 +163,4 @@ Was the build artifact uploaded? Value is `"true"` if the build artifact was upl
 
 - <https://packaging.python.org/en/latest/tutorials/packaging-projects/>
 - <https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/>
+- <https://docs.astral.sh/uv/guides/integration/github/>


### PR DESCRIPTION
- Build Python package using `uv build` instead of `python -m build`. uv is currently the fastest frontend for managing Python projects.
- Rename job `python-build` to `python-package`, a more generic name that reflects what is being built rather than what tools is used to build (i.e., we are no longer using `python -m build`).
- Update workflow documentation accordingly.