### PR TITLE
feat(mkdocs): install dependencies using requirement specifier

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -21,7 +21,7 @@ on:
         default: ">=1.0.0"
 
       requirements:
-        description: The path of a pip requirements file (usually `requirements.txt`) that specifies Python dependencies to install.
+        description: A requirement specifier or the path of a pip requirements file (usually `requirements.txt`) that specifies Python dependencies to install.
         type: string
         required: false
 
@@ -92,7 +92,12 @@ jobs:
         if: inputs.requirements != ''
         env:
           REQUIREMENTS: ${{ inputs.requirements }}
-        run: pip install -r "$REQUIREMENTS"
+        run: |
+          if [[ -f "$REQUIREMENTS" ]]; then
+            pip install -r "$REQUIREMENTS"
+          else
+            pip install "$REQUIREMENTS"
+          fi
 
       - name: MkDocs Build
         env:

--- a/docs/workflows/mkdocs.md
+++ b/docs/workflows/mkdocs.md
@@ -65,7 +65,7 @@ The version of MkDocs to install using pip. Defaults to `>=1.0.0`.
 
 ### (*Optional*) `requirements`
 
-The path of a pip requirements file (usually `requirements.txt`) that specifies dependencies to install.
+A [requirement specifier](https://pip.pypa.io/en/stable/reference/requirement-specifiers/) or the path of a pip requirements file (usually `requirements.txt`) that specifies dependencies to install.
 
 ### (*Optional*) `strict_mode`
 


### PR DESCRIPTION
Allow installing Python dependencies using a requirement specifier instead of a pip requirements file.

Required for projects that install dependencies from a `pyproject.toml` file instead of a `requirements.txt` file (e.g., projects using Poetry or uv).

Workflow documentation has been updated accordingly, with a link to the official documentation for requirement specifiers.