### PR TITLE
refactor: rename workflows, jobs and steps for consistency

### DIFF
--- a/.github/workflows/trivy-config-codeql.yml
+++ b/.github/workflows/trivy-config-codeql.yml
@@ -43,7 +43,7 @@ jobs:
           output: trivy-iac-results.sarif
           limit-severities-for-sarif: true
 
-      - name: Upload SARIF file
+      - name: Upload code scanning results
         uses: github/codeql-action/upload-sarif@0499de31b99561a6d14a36a5f662c2a54f91beee # v4.31.2
         with:
           sarif_file: "trivy-iac-results.sarif"

--- a/.github/workflows/zizmor-codeql.yml
+++ b/.github/workflows/zizmor-codeql.yml
@@ -44,7 +44,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CONFIG_FILE: ${{ inputs.config_file }}
 
-      - name: Upload SARIF file
+      - name: Upload code scanning results
         uses: github/codeql-action/upload-sarif@0499de31b99561a6d14a36a5f662c2a54f91beee # v4.31.2
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Rename workflows `trivy-config-codeql.yml` and `zizmor-codeql.yml` and their contained jobs and steps, following a similar naming convention to all other reusable workflows in this repository.