### PR TITLE
feat(python): install dependencies using requirement specifier

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -27,7 +27,7 @@ on:
         required: false
 
       requirements:
-        description: The path, relative to the working directory, of a pip requirements file.
+        description: A requirement specifier or the path, relative to the working directory, of a requirements file (usually `requirements.txt`) that specifies Python dependencies to install.
         type: string
         required: false
 
@@ -79,13 +79,16 @@ jobs:
           source "$VENV_PATH/bin/activate"
 
       - name: Install dependencies
-        if: inputs.requirements != ''
         env:
           REQUIREMENTS: ${{ inputs.requirements }}
           PIP_TARGET_DIR: ${{ inputs.pip_target_dir }}
         run: |
           python -m pip install --upgrade pip
-          pip install -r "$REQUIREMENTS" --target "$PIP_TARGET_DIR"
+          if [[ -f "$REQUIREMENTS" ]]; then
+            pip install -r "$REQUIREMENTS" --target "$PIP_TARGET_DIR"
+          elif [[ -n "$REQUIREMENTS" ]]; then
+            pip install "$REQUIREMENTS" --target "$PIP_TARGET_DIR"
+          fi
 
       - name: Create tarball
         id: tar

--- a/docs/workflows/python.md
+++ b/docs/workflows/python.md
@@ -111,7 +111,9 @@ The path, relative to the working directory, to create a virtual Python environm
 
 ### (*Optional*) `requirements`
 
-The path, relative to the working directory, of a pip requirements file.
+A [requirement specifier](https://pip.pypa.io/en/stable/reference/requirement-specifiers/) or the path, relative to the working directory, of a requirements file (usually `requirements.txt`) that specifies Python dependencies to install.
+
+For example, set the value to `"."` to install dependencies from a `pyproject.toml` file in the working directory.
 
 ### (*Optional*) `pip_target_dir`
 


### PR DESCRIPTION
Similar to #878.

Allow installing Python dependencies using a requirement specifier instead of a requirements file.

Required for projects that install dependencies from a `pyproject.toml` file instead of a `requirements.txt` file (for example, projects managed using Poetry or uv).

Workflow documentation has been updated accordingly, with a link to the official documentation for requirement specifiers.