### PR TITLE
feat(python): add input `upload_artifact`

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -42,6 +42,12 @@ on:
         required: false
         default: python-app
 
+      upload_artifact:
+        description: Should the build artifact be uploaded?
+        type: boolean
+        required: false
+        default: true
+
     outputs:
       artifact_name:
         description: The name of the uploaded artifact containing the application.
@@ -92,12 +98,14 @@ jobs:
 
       - name: Create tarball
         id: tar
+        if: inputs.upload_artifact
         run: |
           tarball="$RUNNER_TEMP/$ARTIFACT_NAME.tar"
           tar -cf "$tarball" .
           echo "tarball=$tarball" >> "$GITHUB_OUTPUT"
 
       - name: Upload artifact
+        if: inputs.upload_artifact
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: ${{ inputs.artifact_name }}

--- a/docs/workflows/python.md
+++ b/docs/workflows/python.md
@@ -123,6 +123,10 @@ The path, relative to the working directory, of a target directory that pip shou
 
 The name of the build artifact. Defaults to `python-app`.
 
+### (*Optional*) `upload_artifact`
+
+Should the build artifact be uploaded? Defaults to `true`.
+
 ## Outputs
 
 ### `artifact_name`


### PR DESCRIPTION
Similar to #800.

Add an input to control whether or not the build artifact should be uploaded.

For example, use this input to only upload the artifact on push to main. This would allow the workflow to run on PR, to verify that checks pass, without taking up GitHub storage space.