### PR TITLE
fix(databricks-bundle): login to Azure fails with data plane only access

### DIFF
--- a/.github/workflows/databricks-bundle.yml
+++ b/.github/workflows/databricks-bundle.yml
@@ -82,6 +82,9 @@ jobs:
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          # Don't require access to a subscription (i.e., the Databricks compute plane).
+          # Required for service principals that only have access to the Databricks control plane.
+          # Ref: https://learn.microsoft.com/en-us/azure/databricks/getting-started/high-level-architecture#control-plane-and-compute-plane
           allow-no-subscriptions: true
 
       - name: Validate Databricks bundle


### PR DESCRIPTION
Add input allow-no-subscriptions to the azure/login action to, allowing us to set workflow input AZURE_SUBSCRIPTION_ID as optional.