### PR TITLE
ci: downgrade `click` dependency for MkDocs

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,1 +1,2 @@
 mkdocs-material==9.6.22
+click==8.2.1 # click 8.3.0 breaks mkdocs serve live reload


### PR DESCRIPTION
The `mkdocs serve` command uses the `click` Python package for its live reload functionality, however `click` 8.3.0 seems to break that functionality.

To fix this issue, update `requirements-docs.txt` to install `click` 8.2.1 instead.