### PR TITLE
chore(terraform): terraform security hardening

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -79,7 +79,7 @@ on:
         required: false
 
       ENCRYPTION_PASSWORD:
-        description: A password used to encrypt the archive containing the Terraform configuration and plan file.
+        description: A password used to encrypt the archive containing the Terraform configuration and plan file. Passed via `secrets:` so GitHub auto-masks it in all logs.
         required: true
 
       SSH_PRIVATE_KEY:
@@ -114,7 +114,6 @@ env:
   PLAN_FILE: tfplan
   TARBALL: terraform.tar.gpg
   ARTIFACT_NAME: ${{ inputs.artifact_name || format('terraform-{0}', inputs.environment) }}
-  ENCRYPTION_PASSWORD: ${{ secrets.ENCRYPTION_PASSWORD }}
 
 jobs:
   terraform-plan:
@@ -227,7 +226,7 @@ jobs:
           if [[ -n "$VAR_FILE" ]]; then
             optional_args+=(-var-file="$VAR_FILE")
           fi
-          terraform plan -out="$PLAN_FILE" -input=false -detailed-exitcode "${optional_args[@]}"
+          terraform plan -out="$PLAN_FILE" -input=false -detailed-exitcode -lock=false "${optional_args[@]}"
           exitcode=$?
           if [[ "$exitcode" == 1 ]]; then
             exit "$exitcode"
@@ -238,6 +237,8 @@ jobs:
         id: tar
         # Only run if Terraform Plan succeeded with non-empty diff (changes present).
         if: steps.plan.outputs.exitcode == 2
+        env:
+          ENCRYPTION_PASSWORD: ${{ secrets.ENCRYPTION_PASSWORD }}
         run: |
           tarball_path="$RUNNER_TEMP/$TARBALL"
           tar -c . | gpg -c --batch --passphrase "$ENCRYPTION_PASSWORD" -o "$tarball_path"
@@ -251,10 +252,9 @@ jobs:
           name: ${{ env.ARTIFACT_NAME }}
           path: ${{ steps.tar.outputs.tarball_path }}
           if-no-files-found: error
-          # Automatically delete artifact after the workflow run time limit (35 days) to save storage space.
-          # If a workflow reaches this limit, it will be cancelled and the artifact will no longer be needed.
-          # Ref: https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#usage-limits
-          retention-days: 35
+          # The tarball contains the full Terraform configuration and plan (encrypted) and is only consumed by the Apply job in the same workflow run.
+          # Keep retention minimal to limit the exposure window if `ENCRYPTION_PASSWORD` ever leaks.
+          retention-days: 1
 
       - name: Save cache
         id: cache-save
@@ -342,9 +342,11 @@ jobs:
           terraform_wrapper: false
 
       - name: Extract tarball
+        env:
+          ENCRYPTION_PASSWORD: ${{ secrets.ENCRYPTION_PASSWORD }}
         run: |
           gpg -d --batch --passphrase "$ENCRYPTION_PASSWORD" "$TARBALL" | tar -x
           rm "$TARBALL"
 
       - name: Run Terraform Apply
-        run: terraform apply -input=false "$PLAN_FILE"
+        run: terraform apply -input=false -lock-timeout=20m "$PLAN_FILE"

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -49,6 +49,12 @@ on:
         type: string
         required: false
 
+      artifact_retention_days:
+        description: Number of days to retain the uploaded plan artifact. The artifact contains the encrypted Terraform configuration and plan, and is only consumed by the Apply job in the same workflow run. Keep this low to limit the exposure window if `ENCRYPTION_PASSWORD` ever leaks.
+        type: number
+        required: false
+        default: 5
+
       run_terraform_plan:
         description: Run `terraform plan`? Defaults to `false` if the workflow was triggered by Dependabot, else `true`.
         type: boolean
@@ -252,9 +258,7 @@ jobs:
           name: ${{ env.ARTIFACT_NAME }}
           path: ${{ steps.tar.outputs.tarball_path }}
           if-no-files-found: error
-          # The tarball contains the full Terraform configuration and plan (encrypted) and is only consumed by the Apply job in the same workflow run.
-          # Keep retention minimal to limit the exposure window if `ENCRYPTION_PASSWORD` ever leaks.
-          retention-days: 1
+          retention-days: ${{ inputs.artifact_retention_days }}
 
       - name: Save cache
         id: cache-save

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -232,7 +232,7 @@ jobs:
           if [[ -n "$VAR_FILE" ]]; then
             optional_args+=(-var-file="$VAR_FILE")
           fi
-          terraform plan -out="$PLAN_FILE" -input=false -detailed-exitcode -lock=false "${optional_args[@]}"
+          terraform plan -out="$PLAN_FILE" -input=false -detailed-exitcode "${optional_args[@]}"
           exitcode=$?
           if [[ "$exitcode" == 1 ]]; then
             exit "$exitcode"
@@ -353,4 +353,4 @@ jobs:
           rm "$TARBALL"
 
       - name: Run Terraform Apply
-        run: terraform apply -input=false -lock-timeout=20m "$PLAN_FILE"
+        run: terraform apply -input=false "$PLAN_FILE"

--- a/docs/workflows/terraform.md
+++ b/docs/workflows/terraform.md
@@ -103,6 +103,10 @@ The path, relative to the working directory, of a variable definitions file (`.t
 
 The name of the artifact to upload. If not specified, an artifact name will be generated based on the environment name. Defaults to `terraform-<environment>`
 
+### (*Optional*) `artifact_retention_days`
+
+Number of days to retain the uploaded plan artifact. The artifact contains the encrypted Terraform configuration and plan, and is only consumed by the Apply job in the same workflow run. Keep this low to limit the exposure window if `ENCRYPTION_PASSWORD` ever leaks. Defaults to `5`.
+
 ### (*Optional*) `run_terraform_plan`
 
 Run `terraform plan`? Defaults to `false` if the workflow was triggered by Dependabot, else `true`.
@@ -115,7 +119,7 @@ Run `terraform apply` for the saved plan file? Defaults to `true`.
 
 ### `ENCRYPTION_PASSWORD`
 
-A password used to encrypt the archive containing the Terraform configuration and plan file.
+A password used to encrypt the archive containing the Terraform configuration and plan file. Passed via `secrets:` so GitHub auto-masks it in all logs.
 
 ### (*Optional*) `SSH_PRIVATE_KEY`
 


### PR DESCRIPTION
Two small, independent hardening changes to the reusable `terraform.yml` workflow.

## 1. Stop leaking `ENCRYPTION_PASSWORD` to every step

Removed `ENCRYPTION_PASSWORD` from the workflow-level `env:` block and scoped it to only the two steps that actually need it (`Create tarball` in the plan job, `Extract tarball` in the apply job).

Secrets passed via `secrets:` to a reusable workflow are auto-masked by GitHub. Promoting them to a workflow-level `env:` widens exposure to every step (including any third-party actions added later) with no benefit. The secret's description was updated to note this.

## 2. Make plan-tarball retention configurable (default 5 days, was 35)

Added a new `artifact_retention_days` input (number, default `5`) and use it for `retention-days` on the `Upload artifact` step.

The artifact contains the full Terraform configuration and plan, encrypted with `ENCRYPTION_PASSWORD`. It is only consumed by the Apply job in the same workflow run. 35 days of retention is unnecessary exposure window if the password ever leaks. Making it an input lets consumers tune the value to their deployment cadence (e.g. workflows that span multiple environments over several days can opt for a higher value).

This is an additive input change — existing consumers get the new 5-day default automatically without any code changes.

---

The lock-semantics change originally proposed here has been split out into #997.