### PR TITLE
chore(terraform): terraform UX/ergonomics improvements

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -118,7 +118,7 @@ env:
 
 jobs:
   terraform-plan:
-    name: Terraform Plan
+    name: Plan
     runs-on: ${{ inputs.runs_on }}
     environment:
       name: ${{ case(inputs.run_terraform_plan, inputs.environment, '') }}
@@ -173,7 +173,7 @@ jobs:
           # Calculate a hash for the dependency lock file and use this hash to identify the plugin cache for the Terraform configuration.
           # Ref: https://developer.hashicorp.com/terraform/language/files/dependency-lock
 
-      - name: Run Terraform Format
+      - name: Terraform Format
         id: fmt
         # Start Bash without fail-fast behavior.
         # Required in order to check exitcode.
@@ -186,7 +186,7 @@ jobs:
           echo "exitcode=$exitcode" >> "$GITHUB_OUTPUT"
           exit "$exitcode"
 
-      - name: Run Terraform Init
+      - name: Terraform Init
         id: init
         env:
           RUN_TERRAFORM_PLAN: ${{ inputs.run_terraform_plan }}
@@ -205,7 +205,7 @@ jobs:
           fi
           terraform init -input=false "${optional_args[@]}"
 
-      - name: Run Terraform Validate
+      - name: Terraform Validate
         id: validate
         run: terraform validate
 
@@ -213,7 +213,7 @@ jobs:
       # This file contains the full configuration, including sensitive data.
       # As a result, it should be treated as a potentially-sensitive artifact.
       # Ref: https://developer.hashicorp.com/terraform/tutorials/automation/automate-terraform#plan-and-apply-on-different-machines
-      - name: Run Terraform Plan
+      - name: Terraform Plan
         id: plan
         if: inputs.run_terraform_plan
         # Start Bash without fail-fast behavior.
@@ -233,6 +233,14 @@ jobs:
             exit "$exitcode"
           fi
           echo "exitcode=$exitcode" >> "$GITHUB_OUTPUT"
+
+      - name: Show Plan
+        # Only run if Terraform Plan succeeded with non-empty diff (changes present).
+        # Ref: https://developer.hashicorp.com/terraform/cli/commands/plan#detailed-exitcode
+        if: steps.plan.outputs.exitcode == 2
+        shell: bash {0}
+        run: |
+          terraform show "$PLAN_FILE"
 
       - name: Create tarball
         id: tar
@@ -270,30 +278,36 @@ jobs:
         if: steps.fmt.outputs.exitcode != 0 || steps.plan.outputs.exitcode == 2
         shell: bash {0}
         env:
-          TF_FMT_OUTCOME: ${{ steps.fmt.outcome }}
-          TF_INIT_OUTCOME: ${{ steps.init.outcome }}
-          TF_VALIDATE_OUTCOME: ${{ steps.validate.outcome }}
-          TF_PLAN_OUTCOME: ${{ steps.plan.outcome }}
           WORKING_DIRECTORY: ${{ inputs.working_directory }}
         # Some plans are too large to be stored in environment variables or step outputs, resulting in an error.
         # To bypass this, the plan must be explicitly read during this step using the "terraform show" command.
         run: |
           tfplan=$(terraform show "$PLAN_FILE" -no-color)
 
-          echo "#### Terraform Format and Style 🖌\`$TF_FMT_OUTCOME\`
-          #### Terraform Initialization ⚙\`$TF_INIT_OUTCOME\`
-          #### Terraform Validation 🤖\`$TF_VALIDATE_OUTCOME\`
-          #### Terraform Plan 📖\`$TF_PLAN_OUTCOME\`
+          plan_add=$(echo "$tfplan" | grep -oP '\d+(?= to add)' || echo "0")
+          plan_change=$(echo "$tfplan" | grep -oP '\d+(?= to change)' || echo "0")
+          plan_destroy=$(echo "$tfplan" | grep -oP '\d+(?= to destroy)' || echo "0")
 
-          <details><summary>Show Plan</summary>
-
-          \`\`\`terraform
-          $tfplan
-          \`\`\`
-
-          </details>
-
-          *Pusher: @$GITHUB_ACTOR, Action: \`$GITHUB_EVENT_NAME\`, Working Directory: \`$WORKING_DIRECTORY\`, Workflow: \`$GITHUB_WORKFLOW\`*" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "| Add ➕ | Change 🔄 | Destroy 🗑️ |"
+            echo "|---|---|---|"
+            echo "| $plan_add | $plan_change | $plan_destroy |"
+            echo ""
+            total_changes=$((plan_add + plan_change + plan_destroy))
+            if [[ "$total_changes" -gt 2 ]]; then
+              echo "<details><summary>Show Plan</summary>"
+              echo ""
+            fi
+            echo '```terraform'
+            echo "$tfplan"
+            echo '```'
+            if [[ "$total_changes" -gt 2 ]]; then
+              echo ""
+              echo "</details>"
+            fi
+            echo ""
+            echo "*Pusher: @$GITHUB_ACTOR, Action: \`$GITHUB_EVENT_NAME\`, Working Directory: \`$WORKING_DIRECTORY\`, Workflow: \`$GITHUB_WORKFLOW\`*"
+          } >> "$GITHUB_STEP_SUMMARY"
 
     outputs:
       upload-outcome: ${{ steps.upload.outcome }}
@@ -303,7 +317,7 @@ jobs:
       cache-save-outcome: ${{ steps.cache-save.outcome }}
 
   terraform-apply:
-    name: Terraform Apply
+    name: Apply
     needs: terraform-plan
     if: needs.terraform-plan.outputs.upload-outcome == 'success' && inputs.run_terraform_apply
     runs-on: ${{ inputs.runs_on }}
@@ -346,5 +360,5 @@ jobs:
           gpg -d --batch --passphrase "$ENCRYPTION_PASSWORD" "$TARBALL" | tar -x
           rm "$TARBALL"
 
-      - name: Run Terraform Apply
+      - name: Terraform Apply
         run: terraform apply -input=false "$PLAN_FILE"

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -285,18 +285,19 @@ jobs:
           tfplan=$(terraform show "$PLAN_FILE" -no-color)
 
           plan_summary=$(echo "$tfplan" | tail -2)
-          plan_add=$(echo "$plan_summary" | grep -oE '[0-9]+ to add' | grep -oE '[0-9]+' || echo "Count Failed")
-          plan_change=$(echo "$plan_summary" | grep -oE '[0-9]+ to change' | grep -oE '[0-9]+' || echo "Count Failed")
-          plan_destroy=$(echo "$plan_summary" | grep -oE '[0-9]+ to destroy' | grep -oE '[0-9]+' || echo "Count Failed")
+          plan_import=$(echo "$plan_summary" | grep -oE '[0-9]+ to import' | grep -oE '[0-9]+' || echo "0")
+          plan_add=$(echo "$plan_summary" | grep -oE '[0-9]+ to add' | grep -oE '[0-9]+' || echo "Failed")
+          plan_change=$(echo "$plan_summary" | grep -oE '[0-9]+ to change' | grep -oE '[0-9]+' || echo "Failed")
+          plan_destroy=$(echo "$plan_summary" | grep -oE '[0-9]+ to destroy' | grep -oE '[0-9]+' || echo "Failed")
 
           {
-            echo "| Add ➕ | Change 🔄 | Destroy 🗑️ |"
-            echo "|---|---|---|"
-            echo "| $plan_add | $plan_change | $plan_destroy |"
+            echo "| Add ➕ | Change 🔄 | Destroy 🗑️ | Import 📥 |"
+            echo "|---|---|---|---|"
+            echo "| $plan_add | $plan_change | $plan_destroy | $plan_import |"
             echo ""
-            total_changes=$((plan_add + plan_change + plan_destroy))
+            total_changes=$((plan_import + plan_add + plan_change + plan_destroy))
             if [[ "$total_changes" -gt 2 ]]; then
-              echo "<details><summary>Show Plan </summary>"
+              echo "<details><summary>Show Plan ($line_count lines)</summary>"
               echo ""
             fi
             echo '```terraform'

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -118,7 +118,7 @@ env:
 
 jobs:
   terraform-plan:
-    name: Plan
+    name: Terraform Plan
     runs-on: ${{ inputs.runs_on }}
     environment:
       name: ${{ case(inputs.run_terraform_plan, inputs.environment, '') }}
@@ -173,7 +173,7 @@ jobs:
           # Calculate a hash for the dependency lock file and use this hash to identify the plugin cache for the Terraform configuration.
           # Ref: https://developer.hashicorp.com/terraform/language/files/dependency-lock
 
-      - name: Terraform Format
+      - name: Run Terraform Format
         id: fmt
         # Start Bash without fail-fast behavior.
         # Required in order to check exitcode.
@@ -186,7 +186,7 @@ jobs:
           echo "exitcode=$exitcode" >> "$GITHUB_OUTPUT"
           exit "$exitcode"
 
-      - name: Terraform Init
+      - name: Run Terraform Init
         id: init
         env:
           RUN_TERRAFORM_PLAN: ${{ inputs.run_terraform_plan }}
@@ -205,7 +205,7 @@ jobs:
           fi
           terraform init -input=false "${optional_args[@]}"
 
-      - name: Terraform Validate
+      - name: Run Terraform Validate
         id: validate
         run: terraform validate
 
@@ -213,7 +213,7 @@ jobs:
       # This file contains the full configuration, including sensitive data.
       # As a result, it should be treated as a potentially-sensitive artifact.
       # Ref: https://developer.hashicorp.com/terraform/tutorials/automation/automate-terraform#plan-and-apply-on-different-machines
-      - name: Terraform Plan
+      - name: Run Terraform Plan
         id: plan
         if: inputs.run_terraform_plan
         # Start Bash without fail-fast behavior.
@@ -318,7 +318,7 @@ jobs:
       cache-save-outcome: ${{ steps.cache-save.outcome }}
 
   terraform-apply:
-    name: Apply
+    name: Terraform Apply
     needs: terraform-plan
     if: needs.terraform-plan.outputs.upload-outcome == 'success' && inputs.run_terraform_apply
     runs-on: ${{ inputs.runs_on }}
@@ -361,5 +361,5 @@ jobs:
           gpg -d --batch --passphrase "$ENCRYPTION_PASSWORD" "$TARBALL" | tar -x
           rm "$TARBALL"
 
-      - name: Terraform Apply
+      - name: Run Terraform Apply
         run: terraform apply -input=false "$PLAN_FILE"

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -284,9 +284,10 @@ jobs:
         run: |
           tfplan=$(terraform show "$PLAN_FILE" -no-color)
 
-          plan_add=$(echo "$tfplan" | grep -oP '\d+(?= to add)' || echo "0")
-          plan_change=$(echo "$tfplan" | grep -oP '\d+(?= to change)' || echo "0")
-          plan_destroy=$(echo "$tfplan" | grep -oP '\d+(?= to destroy)' || echo "0")
+          plan_summary=$(echo "$tfplan" | tail -2)
+          plan_add=$(echo "$plan_summary" | grep -oE '[0-9]+ to add' | grep -oE '[0-9]+' || echo "Count Failed")
+          plan_change=$(echo "$plan_summary" | grep -oE '[0-9]+ to change' | grep -oE '[0-9]+' || echo "Count Failed")
+          plan_destroy=$(echo "$plan_summary" | grep -oE '[0-9]+ to destroy' | grep -oE '[0-9]+' || echo "Count Failed")
 
           {
             echo "| Add ➕ | Change 🔄 | Destroy 🗑️ |"
@@ -295,7 +296,7 @@ jobs:
             echo ""
             total_changes=$((plan_add + plan_change + plan_destroy))
             if [[ "$total_changes" -gt 2 ]]; then
-              echo "<details><summary>Show Plan</summary>"
+              echo "<details><summary>Show Plan </summary>"
               echo ""
             fi
             echo '```terraform'


### PR DESCRIPTION
Three small, independent UX/ergonomics tweaks to `.github/workflows/terraform.yml`. None affect the public input/output interface of the reusable workflow, so consumers do not need to change anything.

## 1. Richer job summary (add/change/destroy table + collapsible plan)

Replaced the `Create job summary` step. The previous version flat-dumped the plan and prefixed it with four outcome headings.

What changes:

- Surfaces a small markdown table with the **add / change / destroy** counts (parsed from `terraform show` output via grep).
- Wraps the full plan in `<details><summary>` only when there are more than 2 total changes — small drift PRs stay readable inline.
- Drops the four `#### Terraform Format/Init/Validate/Plan ...` outcome lines.

### Why drop the outcome lines?

The summary's `if:` is `steps.fmt.outputs.exitcode != 0 || steps.plan.outputs.exitcode == 2`, so by the time those lines render:

| Step       | Possible value at render time            | Why                                                                                        |
| ---------- | ---------------------------------------- | ------------------------------------------------------------------------------------------ |
| `init`     | always `success`                         | no `continue-on-error`; failure aborts the job before the summary step ever runs           |
| `validate` | always `success`                         | same — failure aborts the job                                                              |
| `plan`     | `success` or `skipped`                   | `exit 1` on real error aborts the job; only `0`/`2` (or skipped via input) get this far    |
| `fmt`      | `success` or `failure`                   | `continue-on-error: true`, but the same status icon is already shown next to the step name |

Three of the four lines are constants when the summary renders, and the fourth duplicates the status icon GitHub Actions already shows in the steps panel. Pure noise.

### Before / after

**Before** (no changes, fmt clean):

> #### Terraform Format and Style 🖌`success`
> #### Terraform Initialization ⚙`success`
> #### Terraform Validation 🤖`success`
> #### Terraform Plan 📖`success`
>
> <details><summary>Show Plan</summary>
>
> ```terraform
> Terraform will perform the following actions:
>
>   # azurerm_resource_group.example will be updated in-place
>   ~ resource "azurerm_resource_group" "example" {
>         tags = {
>       ~     "owner" = "alice" -> "bob"
>         }
>     }
>
> Plan: 0 to add, 1 to change, 0 to destroy.
> ```
>
> </details>
>
> *Pusher: @octocat, Action: `push`, Working Directory: `./infra`, Workflow: `♻ terraform`*

**After** (same plan — small diff, inline):

> | Add ➕ | Change 🔄 | Destroy 🗑️ |
> |---|---|---|
> | 0 | 1 | 0 |
>
> ```terraform
> Terraform will perform the following actions:
>
>   # azurerm_resource_group.example will be updated in-place
>   ~ resource "azurerm_resource_group" "example" {
>         tags = {
>       ~     "owner" = "alice" -> "bob"
>         }
>     }
>
> Plan: 0 to add, 1 to change, 0 to destroy.
> ```
>
> *Pusher: @octocat, Action: `push`, Working Directory: `./infra`, Workflow: `♻ terraform`*

**After** (large refactor — plan collapsed):

> | Add ➕ | Change 🔄 | Destroy 🗑️ |
> |---|---|---|
> | 12 | 4 | 3 |
>
> <details><summary>Show Plan</summary>
>
> ```terraform
> ... full plan body ...
> ```
>
> </details>
>
> *Pusher: @octocat, Action: `push`, Working Directory: `./infra`, Workflow: `♻ terraform`*

The change counts are the number reviewers actually look for first. Putting them in a table at the top makes drift PRs and large refactors instantly distinguishable at a glance, and collapsing the long plan body keeps the summary scannable.

## 2. Add a `Show Plan` step before tarball

A clean output of the plan, without the noisy 'refresh phase'-output, which can be very long in some plans. The cost is near zero in workflow time, but makes it easier to read the plan output.

<img width="1582" height="1080" alt="image" src="https://github.com/user-attachments/assets/c97b8d68-d189-43bf-bdef-37c7a35bf05f" />



---

> [!NOTE]
> An earlier version of this PR also renamed the jobs and steps to drop the redundant `Terraform`/`Run` prefixes. Per [review feedback](https://github.com/equinor/ops-actions/pull/994#issuecomment-4302942716), that change has been reverted from this PR and moved to #996 for separate discussion.