### PR TITLE
docs(terraform): update supported providers for OIDC authentication

### DIFF
--- a/docs/workflows/terraform.md
+++ b/docs/workflows/terraform.md
@@ -24,10 +24,12 @@ Use the [Azure GitHub OIDC Template](https://github.com/equinor/azure-github-oid
 
 This workflow supports OIDC authentication for the following Terraform providers:
 
-| Name  | Source              | Version      |
-| ----- | ------------------- | ------------ |
-| Azure | `hashicorp/azurerm` | `>= v3.20.0` |
-| AzAPI | `azure/azapi`       | `>= v1.3.0`  |
+| Name             | Source                  | Version      |
+| ---------------- | ----------------------- | ------------ |
+| Azure            | `hashicorp/azurerm`     | `>= v3.20.0` |
+| AzAPI            | `azure/azapi`           | `>= v1.3.0`  |
+| Databricks       | `databricks/databricks` | `>= v1.49.0` |
+| Microsoft Fabric | `microsoft/fabric`      | `>= v1.0.0`  |
 
 ### Configure Terraform backend
 


### PR DESCRIPTION
### Databricks provider

- The Databricks Go SDK got support for GitHub Azure OIDC authentication in [v0.43.1](https://github.com/databricks/databricks-sdk-go/releases/tag/v0.43.1) ([databricks/databricks-go-sdk#965](https://github.com/databricks/databricks-sdk-go/pull/965)).
- The Databricks provider got updated to use this SDK version in [v1.49.0](https://github.com/databricks/terraform-provider-databricks/releases/tag/v1.49.0) ([databricks/terraform-provider-databricks#3743](https://github.com/databricks/terraform-provider-databricks/pull/3743)).

### Microsoft Fabric provider

Support for OIDC authentication already in place in initial version.